### PR TITLE
Update to aws sdk v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,9 @@ project/plugins/project/
 # Metals
 .metals/
 .bloop/
-project/metals.sbt
+metals.sbt
 
 #Mac
 .DS_Store
 
-.init-env.sh
+.vscode/

--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,7 @@ lazy val deduplication = (project in file("."))
       "io.chrisdavenport" %% "log4cats-core" % log4CatsVersion,
       "io.chrisdavenport" %% "log4cats-slf4j" % log4CatsVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
+      "org.typelevel" %% "cats-effect-laws" % catsEffectVersion % Test,
       "org.slf4j" % "jcl-over-slf4j" % slf4jVersion % IntegrationTest,
       "org.scalameta" %% "munit" % munitVersion % s"${Test};${IntegrationTest}",
       "org.scalameta" %% "munit-scalacheck" % munitVersion % s"${Test};${IntegrationTest}",

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,12 @@
+val catsVersion = "2.1.1"
+val catsEffectVersion = "2.1.1"
+val slf4jVersion = "1.7.30"
+val scalaJava8CompatVersion = "0.9.1"
+val awsSdkVersion = "2.13.36"
+val log4CatsVersion = "1.1.1"
+val munitVersion = "0.7.9"
+val logBackVersion = "1.2.3"
+
 lazy val deduplication = (project in file("."))
   .enablePlugins(BuildInfoPlugin)
   .configs(IntegrationTest)
@@ -7,11 +16,12 @@ lazy val deduplication = (project in file("."))
     organizationHomepage := Some(url("http://www.ovoenergy.com")),
     licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     scalaVersion := "2.13.1",
-    crossScalaVersions += "2.12.10",
+    crossScalaVersions += "2.12.11",
     scalafmtOnCompile := true,
     scalacOptions -= "-Xfatal-warnings", // enable all options from sbt-tpolecat except fatal warnings
     initialCommands := s"import com.ovoenergy.comms.deduplication._",
     javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation"),
+    testFrameworks += new TestFramework("munit.Framework"),
     addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),
     scmInfo := Some(
       ScmInfo(
@@ -51,32 +61,17 @@ lazy val deduplication = (project in file("."))
     releaseEarlyWith := BintrayPublisher,
     releaseEarlyEnableSyncToMaven := false,
     releaseEarlyNoGpg := true,
-    libraryDependencies ++=
-      dep("org.typelevel")("2.1.1")(
-        "cats-core"
-      ) ++
-        dep("org.typelevel")("2.1.1")(
-          "cats-effect"
-        ) ++
-        dep("org.scala-lang.modules")("0.9.1")(
-          "scala-java8-compat"
-        ) ++
-        udep("software.amazon.awssdk")("2.13.36")(
-          "dynamodb"
-        )++
-        udep("org.slf4j")("1.7.30")(
-          "slf4j-api"
-        ) ++
-        udep("org.slf4j")("1.7.30")(
-          "jcl-over-slf4j"
-        ).map(_ % IntegrationTest) ++
-        Seq(
-          "org.scalatest" %% "scalatest" % "3.2.0",
-          "org.scalacheck" %% "scalacheck" % "1.14.3",
-          "org.scalatestplus" %% "scalacheck-1-14" % "3.1.2.0",
-          "ch.qos.logback" % "logback-classic" % "1.2.3"
-        ).map(_ % IntegrationTest)
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-core" % catsVersion,
+      "org.typelevel" %% "cats-effect" % catsEffectVersion,
+      "org.scala-lang.modules" %% "scala-java8-compat" % scalaJava8CompatVersion,
+      "software.amazon.awssdk" % "dynamodb" % awsSdkVersion,
+      "io.chrisdavenport" %% "log4cats-core" % log4CatsVersion,
+      "io.chrisdavenport" %% "log4cats-slf4j" % log4CatsVersion,
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
+      "org.slf4j" % "jcl-over-slf4j" % slf4jVersion % IntegrationTest,
+      "org.scalameta" %% "munit" % munitVersion % s"${Test};${IntegrationTest}",
+      "org.scalameta" %% "munit-scalacheck" % munitVersion % s"${Test};${IntegrationTest}",
+      "ch.qos.logback" % "logback-classic" % logBackVersion % s"${Test};${IntegrationTest}",
+    )
   )
-
-def dep(org: String)(version: String)(libs: String*) = libs.map(org %% _ % version)
-def udep(org: String)(version: String)(libs: String*) = libs.map(org % _ % version)

--- a/build.sbt
+++ b/build.sbt
@@ -61,10 +61,9 @@ lazy val deduplication = (project in file("."))
         dep("org.scala-lang.modules")("0.9.1")(
           "scala-java8-compat"
         ) ++
-        dep("org.scanamo")("1.0.0-M11")(
-          "scanamo",
-          "scanamo-cats-effect"
-        ) ++
+        udep("software.amazon.awssdk")("2.13.36")(
+          "dynamodb"
+        )++
         udep("org.slf4j")("1.7.30")(
           "slf4j-api"
         ) ++

--- a/src/it/resources/logback-test.xml
+++ b/src/it/resources/logback-test.xml
@@ -10,6 +10,7 @@
 
     <logger name="org.apache.http" level="OFF" />
     <logger name="com.amazonaws.auth.profile.internal.BasicProfileConfigLoader" level="OFF" />
+    <logger name="com.ovoenergy.comms.deduplication" level="DEBUG" />
 
     <root level="WARN">
         <appender-ref ref="Console"/>

--- a/src/it/scala/deduplication/DeduplicationSpec.scala
+++ b/src/it/scala/deduplication/DeduplicationSpec.scala
@@ -6,172 +6,179 @@ import java.util.concurrent.TimeoutException
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
 
 import cats.effect._
 import cats.effect.concurrent._
 import cats.implicits._
 
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import munit._
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder
+import software.amazon.awssdk.services.dynamodb.{model => _, _}
 
 import model._
 import Config._
+import dynamodb.DynamoDbProcessRepo
+import dynamodb.DynamoDbConfig
+import org.scalacheck.Arbitrary
 
-
-class DeduplicationSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class DeduplicationSpec extends FunSuite {
 
   implicit val ec = ExecutionContext.global
   implicit val contextShift = IO.contextShift(ec)
   implicit val timer: Timer[IO] = IO.timer(ec)
 
-  behavior of "Deduplication"
+  override def munitValueTransforms = super.munitValueTransforms ++ List(
+    new ValueTransform("IO", {
+      case io: IO[_] => io.unsafeToFuture()
+    })
+  )
 
-  it should "always process event for the first time" in forAll {
-    (processorId: UUID, id1: UUID, id2: UUID) =>
+  def given[A: Arbitrary]: A = Arbitrary.arbitrary[A].sample.get
 
-      val result = deduplicationResource(processorId)
-        .use { ps =>
-          for {
-            a <- ps.protect(id1, IO("nonProcessed"), IO("processed"))
-            b <- ps.protect(id2, IO("nonProcessed"), IO("processed"))
-          } yield (a, b)
+  test("Deduplication should always process event for the first time") {
+    val processorId = given[UUID]
+    val id1 = given[UUID]
+    val id2 = given[UUID]
+
+    deduplicationResource(processorId)
+      .use { ps =>
+        for {
+          a <- ps.protect(id1, IO("nonProcessed"), IO("processed"))
+          b <- ps.protect(id2, IO("nonProcessed"), IO("processed"))
+        } yield {
+          assertEquals(clue(a), "nonProcessed")
+          assertEquals(clue(b), "nonProcessed")
         }
-        .unsafeRunSync()
-
-      val (a, b) = result
-      a shouldBe "nonProcessed"
-      b shouldBe "nonProcessed"
+      }
   }
 
-  it should "process event for the first time, ignore after that" in forAll {
-    (processorId: UUID, id: UUID) =>
+  test("Deduplication should process event for the first time, ignore after that") {
 
-      val result = deduplicationResource(processorId)
-        .use { ps =>
-          for {
-            a <- ps.protect(id, IO("nonProcessed"), IO("processed"))
-            b <- ps.protect(id, IO("nonProcessed"), IO("processed"))
-          } yield (a, b)
+    val processorId = given[UUID]
+    val id = given[UUID]
+
+    deduplicationResource(processorId)
+      .use { ps =>
+        for {
+          a <- ps.protect(id, IO("nonProcessed"), IO("processed"))
+          b <- ps.protect(id, IO("nonProcessed"), IO("processed"))
+        } yield {
+          assertEquals(clue(a), "nonProcessed")
+          assertEquals(clue(b), "processed")
         }
-        .unsafeRunSync()
-
-      val (a, b) = result
-      a shouldBe "nonProcessed"
-      b shouldBe "processed"
+      }
   }
 
-  it should "re-process the event if it failed the first time" in forAll {
-    (processorId: UUID, id: UUID) =>
+  test("Deduplication should re-process the event if it failed the first time") {
 
-      val result = deduplicationResource(processorId, 1.seconds)
-        .use { ps =>
-          for {
-            ref <- Ref[IO].of(0)
-            _ <- ps.protect(id, IO.raiseError[Unit](new Exception("Expected exception")), IO.unit).attempt
-            _ <- ps.protect(id, ref.set(1), IO.unit)
-            _ <- ps.protect(id, ref.set(3), IO.unit)
-            result <- ref.get
-          } yield result
+    val processorId = given[UUID]
+    val id = given[UUID]
+
+    deduplicationResource(processorId, 1.seconds)
+      .use { ps =>
+        for {
+          ref <- Ref[IO].of(0)
+          _ <- ps
+            .protect(id, IO.raiseError[Unit](new RuntimeException("Expected exception")), IO.unit)
+            .attempt
+          _ <- ps.protect(id, ref.set(1), IO.unit)
+          _ <- ps.protect(id, ref.set(3), IO.unit)
+          result <- ref.get
+        } yield {
+          assertEquals(result, 1)
         }
-        .unsafeRunSync()
-
-      result shouldBe 1
+      }
   }
 
-  it should "process event for the first time, accept other after expiration" in forAll {
-    (processorId: UUID, id: UUID) =>
+  test("Deduplication should process the second event after the first one timeout") {
 
-      val maxProcessingTime = 1.seconds
-      val result = deduplicationResource(processorId, maxProcessingTime)
-        .use { ps =>
-          for {
-            a <- ps.tryStartProcess(id)
-            _ <- IO.sleep(maxProcessingTime + 1.second)
-            bAndTime <- time(ps.tryStartProcess(id))
-          } yield (a, bAndTime)
+    val processorId = given[UUID]
+    val id = given[UUID]
+
+    val maxProcessingTime = 1.seconds
+    deduplicationResource(processorId, maxProcessingTime)
+      .use { ps =>
+        for {
+          _ <- ps.tryStartProcess(id)
+          _ <- IO.sleep(maxProcessingTime + 1.second)
+          result <- ps.tryStartProcess(id)
+        } yield {
+          assert(clue(result).isInstanceOf[Outcome.New[IO]])
         }
-        .unsafeRunSync()
-
-      val (x, (y, yTime)) = result
-      x shouldBe a[Outcome.New[IO]]
-      y shouldBe a[Outcome.New[IO]]
-      yTime should be < maxProcessingTime
+      }
   }
 
-  it should "timeout process if maxPollingTime < maxProcessingTime" in forAll {
-    (processorId: UUID, id: UUID) =>
+  test("Deduplication should fail with timeout if maxPoll < maxProcessingTime") {
 
-      val maxProcessingTime = 15.seconds
-      val maxPollingTime = 1.seconds
+    val processorId = given[UUID]
+    val id = given[UUID]
 
-      val result = deduplicationResource(processorId, maxProcessingTime, maxPollingTime)
-        .use { ps =>
-          for {
-            _ <- ps.tryStartProcess(id)
-            result <- ps.tryStartProcess(id)
-          } yield result
+    val maxProcessingTime = 10.seconds
+    val maxPollingtime = 1.second
+
+    deduplicationResource(processorId, maxProcessingTime, maxPollingtime)
+      .use { ps =>
+        for {
+          _ <- ps.tryStartProcess(id)
+          result <- ps.tryStartProcess(id).attempt
+        } yield {
+          assert(clue(result).isLeft)
+          assert(result.left.exists(_.isInstanceOf[TimeoutException]))
         }
-        .attempt
-        .unsafeRunSync()
+      }
 
-        result shouldBe a[Left[_, _]]
-        result.left.exists(_.isInstanceOf[TimeoutException]) shouldBe true
   }
 
-  it should "process only one event out of multiple concurrent events" in forAll(MinSuccessful(1)) {
-    (processorId: UUID, id: UUID) =>
+  test("Deduplication should process only one event out of multiple concurrent events") {
 
-      val n = 120
+    val processorId = given[UUID]
+    val id = given[UUID]
 
-      val result = deduplicationResource(processorId, maxProcessingTime = 30.seconds)
-        .use { ps =>
-          List.fill(math.abs(n))(id).parTraverse { i =>
-            ps.protect(i, IO(1), IO(0))
+    val n = 120
+
+    deduplicationResource(processorId, maxProcessingTime = 30.seconds)
+      .use { d =>
+        List
+          .fill(math.abs(n))(id)
+          .parTraverse { i =>
+            d.protect(i, IO(1), IO(0))
           }
-        }
-        .unsafeRunSync()
-
-      result.sum shouldBe 1
+          .map { xs =>
+            assertEquals(xs.sum, 1)
+          }
+      }
   }
 
+  // TODO Create and destroy the table
   val tableResource = Resource.liftF(IO(sys.env.getOrElse("TEST_TABLE", "phil-processing")))
 
-  val dynamoDbR: Resource[IO, AmazonDynamoDBAsync] =
-    Resource.make(Sync[IO].delay(AmazonDynamoDBAsyncClientBuilder.defaultClient()))(c =>
-      Sync[IO].delay(c.shutdown())
+  val dynamoDbR: Resource[IO, DynamoDbAsyncClient] =
+    Resource.make(Sync[IO].delay(DynamoDbAsyncClient.builder.build()))(c =>
+      Sync[IO].delay(c.close())
     )
+
+  val processRepoR: Resource[IO, ProcessRepo[IO, UUID, UUID]] = for {
+    table <- tableResource
+    dynamoclient <- dynamoDbR
+  } yield DynamoDbProcessRepo[IO, UUID, UUID](
+    DynamoDbConfig(DynamoDbConfig.TableName(table)),
+    dynamoclient
+  )
 
   def deduplicationResource(
       processorId: UUID,
       maxProcessingTime: FiniteDuration = 5.seconds,
-      maxPollingTime: FiniteDuration = 15.seconds,
-  ): Resource[IO, Deduplication[IO, UUID]] =
+      maxPollingTime: FiniteDuration = 15.seconds
+  ): Resource[IO, Deduplication[IO, UUID, UUID]] =
     for {
-      tableName <- tableResource
-      deduplication <- deduplicationResource(tableName, processorId, maxProcessingTime, maxPollingTime)
-    } yield deduplication
-
-  def deduplicationResource(
-      tableName: String,
-      processorId: UUID,
-      maxProcessingTime: FiniteDuration,
-      maxPollingTime: FiniteDuration,
-  ): Resource[IO, Deduplication[IO, UUID]] =
-    for {
-      deduplication <- Deduplication.resource[IO, UUID, UUID](
-        Config(
-          tableName = Config.TableName(tableName),
-          processorId = processorId,
-          maxProcessingTime = maxProcessingTime,
-          ttl = 1.day,
-          pollStrategy = PollStrategy.backoff(maxDuration = maxPollingTime)
-        )
+      processRepo <- processRepoR
+      config = Config(
+        processorId = processorId,
+        maxProcessingTime = maxProcessingTime,
+        ttl = 1.day,
+        pollStrategy = PollStrategy.backoff(maxDuration = maxPollingTime)
       )
+      deduplication <- Resource.liftF(Deduplication[IO, UUID, UUID](processRepo, config))
     } yield deduplication
 
   def time[F[_]: Sync: Clock, A](fa: F[A]): F[(A, FiniteDuration)] =

--- a/src/it/scala/deduplication/DeduplicationSuite.scala
+++ b/src/it/scala/deduplication/DeduplicationSuite.scala
@@ -21,7 +21,7 @@ import dynamodb.DynamoDbProcessRepo
 import dynamodb.DynamoDbConfig
 import org.scalacheck.Arbitrary
 
-class DeduplicationSpec extends FunSuite {
+class DeduplicationSuite extends FunSuite {
 
   implicit val ec = ExecutionContext.global
   implicit val contextShift = IO.contextShift(ec)

--- a/src/main/scala/deduplication/Config.scala
+++ b/src/main/scala/deduplication/Config.scala
@@ -20,7 +20,6 @@ import Config._
   * @param pollStrategy
   */
 case class Config[ProcessorID](
-    tableName: TableName,
     processorId: ProcessorID,
     maxProcessingTime: FiniteDuration,
     ttl: FiniteDuration,
@@ -28,7 +27,6 @@ case class Config[ProcessorID](
 )
 
 object Config {
-  case class TableName(value: String)
 
   trait PollStrategy {
     def maxPollDuration: FiniteDuration

--- a/src/main/scala/deduplication/Deduplication.scala
+++ b/src/main/scala/deduplication/Deduplication.scala
@@ -13,6 +13,8 @@ import cats.effect._
 
 import com.ovoenergy.comms.deduplication.model._
 import Deduplication._
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import io.chrisdavenport.log4cats.StructuredLogger
 
 object Deduplication {
 
@@ -23,31 +25,44 @@ object Deduplication {
 
   def processStatus[F[_]: Monad: Clock](
       maxProcessingTime: FiniteDuration
-  )(p: Process[_, _]): F[ProcessStatus] =
-    if (p.completedAt.isDefined) {
-      ProcessStatus.Completed.pure[F].widen
-    } else {
-      nowF[F]
-        .map { now =>
-          /*
-           * If the startedAt is:
-           *  - In the past compared to expected finishing time the processed has timeout
-           *  - In the future compared to expected finishing time present the process has started but not yet completed
-           */
-          val isTimeout = p.startedAt
-            .plus(maxProcessingTime.toJava)
-            .isBefore(now)
+  )(p: Process[_, _]): F[ProcessStatus] = nowF[F].map { now =>
 
-          if (isTimeout)
-            ProcessStatus.Timeout
-          else
-            ProcessStatus.Started
-        }
+    val isCompleted =
+      p.completedAt.isDefined
+
+    val isExpired = p.expiresOn
+      .map(_.instant)
+      .exists(_.isBefore(now))
+
+    val isTimeout = p.startedAt
+      .plus(maxProcessingTime.toJava)
+      .isBefore(now)
+
+    if (isCompleted && isExpired) {
+      ProcessStatus.Expired
+    } else if (isCompleted) {
+      ProcessStatus.Completed
+    } else if (isTimeout) {
+      ProcessStatus.Timeout
+    } else {
+      ProcessStatus.Running
     }
+  }
+
+  def apply[F[_]: Sync: Timer, ID, ProcessorID](
+      repo: ProcessRepo[F, ID, ProcessorID],
+      config: Config[ProcessorID]
+  ): F[Deduplication[F, ID, ProcessorID]] = Slf4jLogger.create[F].map { logger =>
+    new Deduplication[F, ID, ProcessorID](repo, config, logger)
+  }
 
 }
 
-class Deduplication[F[_]: Sync: Timer, Id, ProcessorId](repo: ProcessRepo[F, Id, ProcessorId], config: Config[ProcessorId]) {
+class Deduplication[F[_]: Sync: Timer, ID, ProcessorID] private (
+    repo: ProcessRepo[F, ID, ProcessorID],
+    config: Config[ProcessorID],
+    logger: StructuredLogger[F]
+) {
 
   /**
     * Try to start a process.
@@ -74,7 +89,7 @@ class Deduplication[F[_]: Sync: Timer, Id, ProcessorId](repo: ProcessRepo[F, Id,
     * @param id The process id to start
     * @return An Outcome.New or Outcome.Duplicate. The Outcome.New will contain an effect to complete the just started process.
     */
-  def tryStartProcess(id: Id): F[Outcome[F]] = {
+  def tryStartProcess(id: ID): F[Outcome[F]] = {
 
     val pollStrategy = config.pollStrategy
 
@@ -84,8 +99,11 @@ class Deduplication[F[_]: Sync: Timer, Id, ProcessorId](repo: ProcessRepo[F, Id,
         pollDelay: FiniteDuration
     ): F[Outcome[F]] = {
 
+      def logContext =
+        s"processorId=${config.processorId}, id=${id}, startedAt=${startedAt}, pollNo=${pollNo}"
+
       def nextStep(ps: ProcessStatus): F[Outcome[F]] = ps match {
-        case ProcessStatus.Started =>
+        case ProcessStatus.Running =>
           val totalDurationF = nowF[F]
             .map(now => (now.toEpochMilli - startedAt.toEpochMilli).milliseconds)
 
@@ -93,21 +111,43 @@ class Deduplication[F[_]: Sync: Timer, Id, ProcessorId](repo: ProcessRepo[F, Id,
           totalDurationF
             .map(td => td >= pollStrategy.maxPollDuration)
             .ifM(
-              Sync[F].raiseError(new TimeoutException(s"Stop polling after ${pollNo} polls")),
-              Timer[F].sleep(pollDelay) >> doIt(
-                startedAt,
-                pollNo + 1,
-                config.pollStrategy.nextDelay(pollNo, pollDelay)
-              )
+              logger.warn(
+                s"Process still running, stop retry-ing ${logContext}"
+              ) >> Sync[F].raiseError(new TimeoutException(s"Stop polling after ${pollNo} polls")),
+              logger.debug(
+                s"Process still running, retry-ing ${logContext}"
+              ) >>
+                Timer[F].sleep(pollDelay) >>
+                doIt(
+                  startedAt,
+                  pollNo + 1,
+                  config.pollStrategy.nextDelay(pollNo, pollDelay)
+                )
             )
-        case ProcessStatus.NotStarted | ProcessStatus.Timeout =>
-          Outcome
-            .New(nowF[F].flatMap(now => repo.completeProcess(id, config.processorId, now)))
-            .pure[F]
+        case ProcessStatus.NotStarted | ProcessStatus.Timeout | ProcessStatus.Expired =>
+          logger
+            .debug(
+              s"Process status is ${ps}, starting now ${logContext}"
+            )
+            .map { _ =>
+              Outcome.New(
+                nowF[F].flatMap { now =>
+                  repo.completeProcess(id, config.processorId, now, config.ttl).flatTap { _ =>
+                    logger.debug(
+                      s"Process marked as completed ${logContext}"
+                    )
+                  }
+                }
+              )
+            }
             .widen[Outcome[F]]
 
         case ProcessStatus.Completed =>
-          Monad[F].point(Outcome.Duplicate())
+          logger
+            .debug(
+              s"Process is duplicated processorId=${config.processorId}, id=${id}, startedAt=${startedAt}"
+            )
+            .as(Outcome.Duplicate())
       }
 
       for {
@@ -136,7 +176,7 @@ class Deduplication[F[_]: Sync: Timer, Id, ProcessorId](repo: ProcessRepo[F, Id,
     * @param ifDuplicate The effect to run if the process is duplicate.
     * @return the result of [[ifNew]] or [[ifDuplicate]].
     */
-  def protect[A](id: Id, ifNew: F[A], ifDuplicate: F[A]): F[A] = {
+  def protect[A](id: ID, ifNew: F[A], ifDuplicate: F[A]): F[A] = {
     tryStartProcess(id)
       .flatMap {
         case Outcome.New(markAsComplete) =>

--- a/src/main/scala/deduplication/Deduplication.scala
+++ b/src/main/scala/deduplication/Deduplication.scala
@@ -6,79 +6,15 @@ import java.util.concurrent.TimeoutException
 
 import scala.concurrent.duration._
 import scala.compat.java8.DurationConverters._
-import scala.collection.JavaConverters._
 
 import cats._
 import cats.implicits._
 import cats.effect._
-import cats.effect.implicits._
 
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder}
-import com.amazonaws.services.dynamodbv2.model._
-import com.amazonaws.handlers._
-import org.scanamo._
-import org.scanamo.error.{DynamoReadError, NoPropertyOfType}
-
-import model._
-import ScanamoHelpers._
-
-/**
-  *
-  */
-trait Deduplication[F[_], ID] {
-
-  /**
-    * Try to start a process.
-    *
-    * If the process with the giving id has never started before, this will start a new process and return Some(complete)
-    * If another process with the same id has already completed, this will do nothing and return None
-    * If another process with the same id has already started and timeouted, this will do nothing and return None
-    * If another process with the same id is still running, this will wait until it will complete or timeout
-    *
-    * If markAsComplete fails, the process will likely be duplicated.
-    * If the process takes more time than maxProcessingTime, you may have duplicate if two processes with same ID happen at the same time
-    *
-    * eg
-    * ```
-    * tryStartProcess(id)
-    *   .flatMap {
-    *     case Outcome.New(markAsComplete) =>
-    *       doYourStuff.flatTap(_ => markAsComplete)
-    *     case Outcome.Duplicate() =>
-    *       dontDoYourStuff
-    *   }
-    * ```
-    *
-    * @param id The process id to start
-    * @return An Outcome.New or Outcome.Duplicate. The Outcome.New will contain an effect to complete the just started process.
-    */
-  def tryStartProcess(id: ID): F[Outcome[F]]
-
-  /**
-    * Do the best effort to ensure a process to be successfully executed only once.
-    *
-    * If the process has already runned successfully before, it will run the [[ifDuplicate]].
-    * Otherwise, it will run the [[ifNew]].
-    *
-    * The return value is either the result of [[ifNew]] or [[ifDuplicate]].
-    *
-    * @param id The id of the process to run.
-    * @param ifNew The effect to run if the process is new.
-    * @param ifDuplicate The effect to run if the process is duplicate.
-    * @return the result of [[ifNew]] or [[ifDuplicate]].
-    */
-  def protect[A](id: ID, ifNew: F[A], ifDuplicate: F[A]): F[A]
-}
+import com.ovoenergy.comms.deduplication.model._
+import Deduplication._
 
 object Deduplication {
-
-  private object field {
-    val id = "id"
-    val processorId = "processorId"
-    val startedAt = "startedAt"
-    val completedAt = "completedAt"
-    val expiresOn = "expiresOn"
-  }
 
   def nowF[F[_]: Functor: Clock] =
     Clock[F]
@@ -109,235 +45,104 @@ object Deduplication {
         }
     }
 
-  private implicit def optionFormat[T](implicit f: DynamoFormat[T]) = new DynamoFormat[Option[T]] {
-    def read(av: DynamoValue): Either[DynamoReadError, Option[T]] =
-      read(av.toAttributeValue)
-
-    override def read(av: AttributeValue): Either[DynamoReadError, Option[T]] =
-      Option(av)
-        .filter(x => !Boolean.unbox(x.isNULL))
-        .map(f.read(_).map(Some(_)))
-        .getOrElse(Right(Option.empty[T]))
-
-    def write(t: Option[T]): DynamoValue = t.map(f.write).getOrElse(DynamoValue.nil)
-  }
-
-  private implicit val instantDynamoFormat: DynamoFormat[Instant] =
-    DynamoFormat.coercedXmap[Instant, Long, IllegalArgumentException](Instant.ofEpochMilli)(
-      _.toEpochMilli
-    )
-
-  private implicit val expirationDynamoFormat: DynamoFormat[Expiration] =
-    DynamoFormat.coercedXmap[Expiration, Long, IllegalArgumentException](x =>
-      Expiration(Instant.ofEpochSecond(x))
-    )(_.instant.getEpochSecond)
-
-  private implicit def processDynamoFormat[ID: DynamoFormat, ProcessorID: DynamoFormat]
-      : DynamoFormat[Process[ID, ProcessorID]] = new DynamoFormat[Process[ID, ProcessorID]] {
-
-    def read(av: DynamoValue): Either[DynamoReadError, Process[ID, ProcessorID]] =
-      for {
-        obj <- av.asObject
-          .toRight(NoPropertyOfType("object", av))
-          .leftWiden[DynamoReadError]
-        id <- obj.get[ID](field.id)
-        processorId <- obj.get[ProcessorID](field.processorId)
-        startedAt <- obj.get[Instant](field.startedAt)
-        completedAt <- obj.get[Option[Instant]](field.completedAt)
-        expiresOn <- obj.get[Option[Expiration]](field.expiresOn)
-      } yield Process(id, processorId, startedAt, completedAt, expiresOn)
-
-    def write(process: Process[ID, ProcessorID]): DynamoValue =
-      DynamoObject(
-        field.id -> DynamoFormat[ID].write(process.id),
-        field.processorId -> DynamoFormat[ProcessorID].write(process.processorId),
-        field.startedAt -> DynamoFormat[Instant].write(process.startedAt),
-        field.completedAt -> DynamoFormat[Option[Instant]].write(process.completedAt),
-        field.expiresOn -> DynamoFormat[Option[Expiration]].write(process.expiresOn)
-      ).toDynamoValue
-  }
-
-  def resource[F[_]: Async: ContextShift: Timer, ID: DynamoFormat, ProcessorID: DynamoFormat](
-      config: Config[ProcessorID]
-  ): Resource[F, Deduplication[F, ID]] = {
-    val dynamoDbR: Resource[F, AmazonDynamoDBAsync] =
-      Resource.make(Sync[F].delay(AmazonDynamoDBAsyncClientBuilder.defaultClient()))(c =>
-        Sync[F].delay(c.shutdown())
-      )
-
-    dynamoDbR.map { client => Deduplication(config, client) }
-  }
-
-  def apply[F[_]: Async: ContextShift: Timer, ID: DynamoFormat, ProcessorID: DynamoFormat](
-      config: Config[ProcessorID],
-      client: AmazonDynamoDBAsync
-  ): Deduplication[F, ID] = {
-
-    def update(request: UpdateItemRequest) =
-      Async[F]
-        .async[UpdateItemResult] { cb =>
-          client.updateItemAsync(
-            request,
-            new AsyncHandler[UpdateItemRequest, UpdateItemResult] {
-              def onError(exception: Exception) = {
-                cb(Left(exception))
-              }
-
-              def onSuccess(req: UpdateItemRequest, res: UpdateItemResult) = {
-                cb(Right(res))
-              }
-            }
-          )
-
-          ()
-        }
-        .guarantee(ContextShift[F].shift)
-
-    // Unfurtunately Scanamo does not support update of non existing record
-    def startProcessingUpdate(
-        id: ID,
-        processorId: ProcessorID,
-        now: Instant
-    ): F[Option[Process[ID, ProcessorID]]] = {
-
-      val startedAtVar = ":startedAt"
-
-      val result = update(
-        new UpdateItemRequest()
-          .withTableName(config.tableName.value)
-          .withKey(
-            Map(
-              field.id -> DynamoFormat[ID].write(id).toAttributeValue,
-              field.processorId -> DynamoFormat[ProcessorID].write(processorId).toAttributeValue
-            ).asJava
-          )
-          .withUpdateExpression(
-            s"SET ${field.startedAt} = if_not_exists(${field.startedAt}, ${startedAtVar})"
-          )
-          .withExpressionAttributeValues(
-            Map(
-              startedAtVar -> instantDynamoFormat.write(now).toAttributeValue
-            ).asJava
-          )
-          .withReturnValues(ReturnValue.ALL_OLD)
-      )
-
-      result.map { res =>
-        Option(res.getAttributes)
-          .filter(_.size > 0)
-          .map(xs => new AttributeValue().withM(xs))
-          .traverse { atts =>
-            DynamoFormat[Process[ID, ProcessorID]]
-              .read(atts)
-              .leftMap(e => new Exception(show"Error reading old item: ${e}"))
-          }
-      }.rethrow
-    }
-
-    new Deduplication[F, ID] {
-
-      override def tryStartProcess(id: ID): F[Outcome[F]] = {
-
-        val completeProcess: F[Unit] = {
-
-          val completedAtVar = ":completedAt"
-          val expiresOnVar = ":expiresOn"
-
-          for {
-            now <- nowF[F]
-            _ <- update(
-              new UpdateItemRequest()
-                .withTableName(config.tableName.value)
-                .withKey(
-                  Map(
-                    field.id -> DynamoFormat[ID].write(id).toAttributeValue,
-                    field.processorId -> DynamoFormat[ProcessorID]
-                      .write(config.processorId)
-                      .toAttributeValue
-                  ).asJava
-                )
-                .withUpdateExpression(
-                  s"SET ${field.completedAt}=${completedAtVar}, ${field.expiresOn}=${expiresOnVar}"
-                )
-                .withExpressionAttributeValues(
-                  Map(
-                    completedAtVar -> instantDynamoFormat.write(now).toAttributeValue,
-                    expiresOnVar -> new AttributeValue()
-                      .withN(now.plus(config.ttl.toJava).getEpochSecond().toString)
-                  ).asJava
-                )
-                .withReturnValues(ReturnValue.NONE)
-            )
-          } yield ()
-        }
-
-        val pollStrategy = config.pollStrategy
-
-        def doIt(
-            startedAt: Instant,
-            pollNo: Int,
-            pollDelay: FiniteDuration
-        ): F[Outcome[F]] = {
-
-          def nextStep(ps: ProcessStatus): F[Outcome[F]] = ps match {
-            case ProcessStatus.Started =>
-              val totalDurationF = nowF[F]
-                .map(now => (now.toEpochMilli - startedAt.toEpochMilli).milliseconds)
-
-              // retry until it is either Completed or Timeout
-              totalDurationF
-                .map(td => td >= pollStrategy.maxPollDuration)
-                .ifM(
-                  Sync[F].raiseError(new TimeoutException(s"Stop polling after ${pollNo} polls")),
-                  Timer[F].sleep(pollDelay) >> doIt(
-                    startedAt,
-                    pollNo + 1,
-                    config.pollStrategy.nextDelay(pollNo, pollDelay)
-                  )
-                )
-            case ProcessStatus.NotStarted | ProcessStatus.Timeout =>
-              Outcome.New(completeProcess).pure[F].widen[Outcome[F]]
-
-            case ProcessStatus.Completed =>
-              Monad[F].point(Outcome.Duplicate())
-          }
-
-          for {
-            now <- nowF[F]
-            processOpt <- startProcessingUpdate(id, config.processorId, now)
-            status <- processOpt
-              .traverse(processStatus[F](config.maxProcessingTime))
-              .map(_.getOrElse(ProcessStatus.NotStarted))
-            sample <- nextStep(status)
-          } yield sample
-        }
-
-        nowF[F].flatMap(now => doIt(now, 0, pollStrategy.initialDelay))
-      }
-
-      override def protect[A](id: ID, ifNotSeen: F[A], ifSeen: F[A]): F[A] = {
-        tryStartProcess(id)
-          .flatMap {
-            case Outcome.New(markAsComplete) =>
-              ifNotSeen.flatTap(_ => markAsComplete)
-            case Outcome.Duplicate() =>
-              ifSeen
-          }
-      }
-    }
-  }
 }
 
-/*
- * TODO: Remove this once upgrade to later version of Scanamo
- * This method exists in 1.0.0-M12 but because of this issue:
- * https://github.com/scanamo/scanamo/issues/583, we cannot use M12 because
- * it writes List[T] to a Map if T is not a primitive type. As a result, we
- * need to use M11 which does not have this `get` method
- */
-object ScanamoHelpers {
-  implicit class DynObjExtras(obj: DynamoObject) {
-    def get[A: DynamoFormat](key: String): Either[DynamoReadError, A] =
-      obj(key).getOrElse(DynamoValue.nil).as[A]
+class Deduplication[F[_]: Sync: Timer, Id, ProcessorId](repo: ProcessRepo[F, Id, ProcessorId], config: Config[ProcessorId]) {
+
+  /**
+    * Try to start a process.
+    *
+    * If the process with the giving id has never started before, this will start a new process and return Some(complete)
+    * If another process with the same id has already completed, this will do nothing and return None
+    * If another process with the same id has already started and timeouted, this will do nothing and return None
+    * If another process with the same id is still running, this will wait until it will complete or timeout
+    *
+    * If markAsComplete fails, the process will likely be duplicated.
+    * If the process takes more time than maxProcessingTime, you may have duplicate if two processes with same ID happen at the same time
+    *
+    * eg
+    * ```
+    * tryStartProcess(id)
+    *   .flatMap {
+    *     case Outcome.New(markAsComplete) =>
+    *       doYourStuff.flatTap(_ => markAsComplete)
+    *     case Outcome.Duplicate() =>
+    *       dontDoYourStuff
+    *   }
+    * ```
+    *
+    * @param id The process id to start
+    * @return An Outcome.New or Outcome.Duplicate. The Outcome.New will contain an effect to complete the just started process.
+    */
+  def tryStartProcess(id: Id): F[Outcome[F]] = {
+
+    val pollStrategy = config.pollStrategy
+
+    def doIt(
+        startedAt: Instant,
+        pollNo: Int,
+        pollDelay: FiniteDuration
+    ): F[Outcome[F]] = {
+
+      def nextStep(ps: ProcessStatus): F[Outcome[F]] = ps match {
+        case ProcessStatus.Started =>
+          val totalDurationF = nowF[F]
+            .map(now => (now.toEpochMilli - startedAt.toEpochMilli).milliseconds)
+
+          // retry until it is either Completed or Timeout
+          totalDurationF
+            .map(td => td >= pollStrategy.maxPollDuration)
+            .ifM(
+              Sync[F].raiseError(new TimeoutException(s"Stop polling after ${pollNo} polls")),
+              Timer[F].sleep(pollDelay) >> doIt(
+                startedAt,
+                pollNo + 1,
+                config.pollStrategy.nextDelay(pollNo, pollDelay)
+              )
+            )
+        case ProcessStatus.NotStarted | ProcessStatus.Timeout =>
+          Outcome
+            .New(nowF[F].flatMap(now => repo.completeProcess(id, config.processorId, now)))
+            .pure[F]
+            .widen[Outcome[F]]
+
+        case ProcessStatus.Completed =>
+          Monad[F].point(Outcome.Duplicate())
+      }
+
+      for {
+        now <- nowF[F]
+        processOpt <- repo.startProcessingUpdate(id, config.processorId, now)
+        status <- processOpt
+          .traverse(processStatus[F](config.maxProcessingTime))
+          .map(_.getOrElse(ProcessStatus.NotStarted))
+        sample <- nextStep(status)
+      } yield sample
+    }
+
+    nowF[F].flatMap(now => doIt(now, 0, pollStrategy.initialDelay))
+  }
+
+  /**
+    * Do the best effort to ensure a process to be successfully executed only once.
+    *
+    * If the process has already runned successfully before, it will run the [[ifDuplicate]].
+    * Otherwise, it will run the [[ifNew]].
+    *
+    * The return value is either the result of [[ifNew]] or [[ifDuplicate]].
+    *
+    * @param id The id of the process to run.
+    * @param ifNew The effect to run if the process is new.
+    * @param ifDuplicate The effect to run if the process is duplicate.
+    * @return the result of [[ifNew]] or [[ifDuplicate]].
+    */
+  def protect[A](id: Id, ifNew: F[A], ifDuplicate: F[A]): F[A] = {
+    tryStartProcess(id)
+      .flatMap {
+        case Outcome.New(markAsComplete) =>
+          ifNew.flatTap(_ => markAsComplete)
+        case Outcome.Duplicate() =>
+          ifDuplicate
+      }
   }
 }

--- a/src/main/scala/deduplication/Deduplication.scala
+++ b/src/main/scala/deduplication/Deduplication.scala
@@ -68,10 +68,10 @@ class Deduplication[F[_]: Sync: Timer, ID, ProcessorID] private (
   /**
     * Try to start a process.
     *
-    * If the process with the giving id has never started before, this will start a new process and return Some(complete)
-    * If another process with the same id has already completed, this will do nothing and return None
-    * If another process with the same id has already started and timeouted, this will do nothing and return None
-    * If another process with the same id is still running, this will wait until it will complete or timeout
+    * If the process with the giving id has never started before, this will start a new process and return Outcome.New
+    * If another process with the same id has already completed, this will do nothing and return Outcome.Duplicate
+    * If another process with the same id has already started and timeouted, this will start a new process and return Outcome.New
+    * If another process with the same id is still running, this will wait until it will complete or timeout and return Outcome.Duplicate or Outcome.New
     *
     * If markAsComplete fails, the process will likely be duplicated.
     * If the process takes more time than maxProcessingTime, you may have duplicate if two processes with same ID happen at the same time

--- a/src/main/scala/deduplication/ProcessRepo.scala
+++ b/src/main/scala/deduplication/ProcessRepo.scala
@@ -1,0 +1,22 @@
+package com.ovoenergy.comms.deduplication
+
+import java.time.Instant
+
+import model._
+import scala.concurrent.duration.FiniteDuration
+
+trait ProcessRepo[F[_], ID, ProcessorID] {
+
+  def startProcessingUpdate(
+      id: ID,
+      processorId: ProcessorID,
+      now: Instant
+  ): F[Option[Process[ID, ProcessorID]]]
+
+  def completeProcess(
+      id: ID,
+      processorId: ProcessorID,
+      now: Instant,
+      ttl: FiniteDuration
+  ): F[Unit]
+}

--- a/src/main/scala/deduplication/dynamodb/DynamoDbConfig.scala
+++ b/src/main/scala/deduplication/dynamodb/DynamoDbConfig.scala
@@ -1,0 +1,13 @@
+package com.ovoenergy.comms.deduplication
+package dynamodb
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClientBuilder
+
+case class DynamoDbConfig(
+    tableName: DynamoDbConfig.TableName,
+    modifyClientBuilder: DynamoDbAsyncClientBuilder => DynamoDbAsyncClientBuilder = identity
+)
+
+object DynamoDbConfig {
+  case class TableName(value: String)
+}

--- a/src/main/scala/deduplication/dynamodb/DynamoDbDecoder.scala
+++ b/src/main/scala/deduplication/dynamodb/DynamoDbDecoder.scala
@@ -1,6 +1,7 @@
 package com.ovoenergy.comms.deduplication
 package dynamodb
 
+import java.{util => ju}
 import java.time.Instant
 
 import scala.collection.JavaConverters._
@@ -12,14 +13,15 @@ import software.amazon.awssdk.services.dynamodb.model._
 
 import scala.annotation.tailrec
 
-case class DecoderFailure(message: String, cause: Option[Throwable] = None) extends RuntimeException(message, cause.getOrElse(null))
+case class DecoderFailure(message: String, cause: Option[Throwable] = None)
+    extends RuntimeException(message, cause.getOrElse(null))
 
 trait DynamoDbDecoder[A] {
   def read(av: AttributeValue): Either[DecoderFailure, A]
 }
 
 object DynamoDbDecoder {
-  
+
   def apply[A](implicit dd: DynamoDbDecoder[A]): DynamoDbDecoder[A] = dd
 
   def instance[A](f: AttributeValue => Either[DecoderFailure, A]): DynamoDbDecoder[A] =
@@ -37,27 +39,31 @@ object DynamoDbDecoder {
 
   implicit def monadForDynamoDbDecoder: Monad[DynamoDbDecoder] = new Monad[DynamoDbDecoder] {
 
-    def pure[A](x: A): DynamoDbDecoder[A] = DynamoDbDecoder.instance[A](_ => x.asRight[DecoderFailure])
+    def pure[A](x: A): DynamoDbDecoder[A] =
+      DynamoDbDecoder.instance[A](_ => x.asRight[DecoderFailure])
 
     def flatMap[A, B](fa: DynamoDbDecoder[A])(f: A => DynamoDbDecoder[B]): DynamoDbDecoder[B] =
       new DynamoDbDecoder[B] {
-        def read(av: AttributeValue): Either[DecoderFailure, B] = fa.read(av).flatMap(a => f(a).read(av))
+        def read(av: AttributeValue): Either[DecoderFailure, B] =
+          fa.read(av).flatMap(a => f(a).read(av))
       }
 
     def tailRecM[A, B](init: A)(f: A => DynamoDbDecoder[Either[A, B]]): DynamoDbDecoder[B] =
       new DynamoDbDecoder[B] {
         @tailrec
-        private def step(av: AttributeValue, a: A): Either[DecoderFailure, B] = f(a).read(av) match {
-          case l @ Left(_) => l.rightCast[B]
-          case Right(Left(a2)) => step(av, a2)
-          case Right(Right(b)) => Right(b)
-        }
+        private def step(av: AttributeValue, a: A): Either[DecoderFailure, B] =
+          f(a).read(av) match {
+            case l @ Left(_) => l.rightCast[B]
+            case Right(Left(a2)) => step(av, a2)
+            case Right(Right(b)) => Right(b)
+          }
 
         def read(av: AttributeValue): Either[DecoderFailure, B] = step(av, init)
       }
   }
 
-  implicit val dynamoDecoderForAttributeValue: DynamoDbDecoder[AttributeValue] = DynamoDbDecoder.instance(av => av.asRight[DecoderFailure])
+  implicit val dynamoDecoderForAttributeValue: DynamoDbDecoder[AttributeValue] =
+    DynamoDbDecoder.instance(av => av.asRight[DecoderFailure])
 
   implicit def dynamoDecoderForOption[A: DynamoDbDecoder]: DynamoDbDecoder[Option[A]] =
     DynamoDbDecoder.instance { av =>
@@ -72,43 +78,66 @@ object DynamoDbDecoder {
     Option(av.s()).toRight(new DecoderFailure(s"The attribute value must be an S"))
   }
 
+  implicit val dynamoDecoderForUUID: DynamoDbDecoder[ju.UUID] = DynamoDbDecoder[String].flatMap {
+    str =>
+      Either
+        .catchNonFatal(ju.UUID.fromString(str))
+        .fold(
+          e => DynamoDbDecoder.failed(DecoderFailure(e.getMessage, e.some)),
+          ok => DynamoDbDecoder.const(ok)
+        )
+  }
+
   implicit val dynamoDecoderForBoolean: DynamoDbDecoder[Boolean] = DynamoDbDecoder.instance { av =>
-    Option(av.bool()).map(_.booleanValue()).toRight(new DecoderFailure(s"The attribute value must be an B"))
+    Option(av.bool())
+      .map(_.booleanValue())
+      .toRight(new DecoderFailure(s"The attribute value must be an B"))
   }
 
   implicit val dynamoDecoderForLong: DynamoDbDecoder[Long] = DynamoDbDecoder.instance { av =>
     Option(av.n())
       .toRight(new DecoderFailure(s"The attribute value must be an N"))
-      .flatMap(n => Either.catchNonFatal(n.toLong).leftMap(e => DecoderFailure(e.getMessage(), e.some)))
+      .flatMap(n =>
+        Either.catchNonFatal(n.toLong).leftMap(e => DecoderFailure(e.getMessage(), e.some))
+      )
   }
 
   implicit val dynamoDecoderForInt: DynamoDbDecoder[Int] = DynamoDbDecoder.instance { av =>
     Option(av.n())
       .toRight(new DecoderFailure(s"The attribute value must be an N"))
-      .flatMap(n => Either.catchNonFatal(n.toInt).leftMap(e => DecoderFailure(e.getMessage(), e.some)))
+      .flatMap(n =>
+        Either.catchNonFatal(n.toInt).leftMap(e => DecoderFailure(e.getMessage(), e.some))
+      )
   }
 
-  implicit val dynamoDecoderForInstant: DynamoDbDecoder[Instant] = dynamoDecoderForLong.flatMap { ms =>
-    Either.catchNonFatal(Instant.ofEpochMilli(ms)).fold(
-      e => DynamoDbDecoder.failed(DecoderFailure(e.getMessage(), e.some)),
-      ok => DynamoDbDecoder.const(ok)
-    )
+  implicit val dynamoDecoderForInstant: DynamoDbDecoder[Instant] = dynamoDecoderForLong.flatMap {
+    ms =>
+      Either
+        .catchNonFatal(Instant.ofEpochMilli(ms))
+        .fold(
+          e => DynamoDbDecoder.failed(DecoderFailure(e.getMessage(), e.some)),
+          ok => DynamoDbDecoder.const(ok)
+        )
   }
 
-  implicit def dynamoDecoderForMap[A: DynamoDbDecoder]: DynamoDbDecoder[Map[String, A]] = instance { av =>
-    if(av.hasM()) {
-      av.m().asScala.map { case (k, v) =>
-        (k, DynamoDbDecoder[A].read(v))
-      }.foldLeft(Map.empty[String, A].asRight[DecoderFailure]){(fs, fx) =>
-        for {
-          s <- fs
-          x <- fx._2
-        } yield s + (fx._1 -> x)
+  implicit def dynamoDecoderForMap[A: DynamoDbDecoder]: DynamoDbDecoder[Map[String, A]] = instance {
+    av =>
+      if (av.hasM()) {
+        av.m()
+          .asScala
+          .map {
+            case (k, v) =>
+              (k, DynamoDbDecoder[A].read(v))
+          }
+          .foldLeft(Map.empty[String, A].asRight[DecoderFailure]) { (fs, fx) =>
+            for {
+              s <- fs
+              x <- fx._2
+            } yield s + (fx._1 -> x)
+          }
+      } else {
+        DecoderFailure("The AttributeValue must be an M").asLeft[Map[String, A]]
       }
-    } else {
-      DecoderFailure("The AttributeValue must be an M").asLeft[Map[String, A]]
-    }
   }
 
 }
-

--- a/src/main/scala/deduplication/dynamodb/DynamoDbDecoder.scala
+++ b/src/main/scala/deduplication/dynamodb/DynamoDbDecoder.scala
@@ -1,0 +1,114 @@
+package com.ovoenergy.comms.deduplication
+package dynamodb
+
+import java.time.Instant
+
+import scala.collection.JavaConverters._
+
+import cats._
+import cats.implicits._
+
+import software.amazon.awssdk.services.dynamodb.model._
+
+import scala.annotation.tailrec
+
+case class DecoderFailure(message: String, cause: Option[Throwable] = None) extends RuntimeException(message, cause.getOrElse(null))
+
+trait DynamoDbDecoder[A] {
+  def read(av: AttributeValue): Either[DecoderFailure, A]
+}
+
+object DynamoDbDecoder {
+  
+  def apply[A](implicit dd: DynamoDbDecoder[A]): DynamoDbDecoder[A] = dd
+
+  def instance[A](f: AttributeValue => Either[DecoderFailure, A]): DynamoDbDecoder[A] =
+    new DynamoDbDecoder[A] {
+      def read(av: AttributeValue): Either[DecoderFailure, A] = f(av)
+    }
+
+  def failed[A](failure: DecoderFailure): DynamoDbDecoder[A] = new DynamoDbDecoder[A] {
+    def read(av: AttributeValue): Either[DecoderFailure, A] = failure.asLeft[A]
+  }
+
+  def const[A](a: A): DynamoDbDecoder[A] = new DynamoDbDecoder[A] {
+    def read(av: AttributeValue): Either[DecoderFailure, A] = a.asRight[DecoderFailure]
+  }
+
+  implicit def monadForDynamoDbDecoder: Monad[DynamoDbDecoder] = new Monad[DynamoDbDecoder] {
+
+    def pure[A](x: A): DynamoDbDecoder[A] = DynamoDbDecoder.instance[A](_ => x.asRight[DecoderFailure])
+
+    def flatMap[A, B](fa: DynamoDbDecoder[A])(f: A => DynamoDbDecoder[B]): DynamoDbDecoder[B] =
+      new DynamoDbDecoder[B] {
+        def read(av: AttributeValue): Either[DecoderFailure, B] = fa.read(av).flatMap(a => f(a).read(av))
+      }
+
+    def tailRecM[A, B](init: A)(f: A => DynamoDbDecoder[Either[A, B]]): DynamoDbDecoder[B] =
+      new DynamoDbDecoder[B] {
+        @tailrec
+        private def step(av: AttributeValue, a: A): Either[DecoderFailure, B] = f(a).read(av) match {
+          case l @ Left(_) => l.rightCast[B]
+          case Right(Left(a2)) => step(av, a2)
+          case Right(Right(b)) => Right(b)
+        }
+
+        def read(av: AttributeValue): Either[DecoderFailure, B] = step(av, init)
+      }
+  }
+
+  implicit val dynamoDecoderForAttributeValue: DynamoDbDecoder[AttributeValue] = DynamoDbDecoder.instance(av => av.asRight[DecoderFailure])
+
+  implicit def dynamoDecoderForOption[A: DynamoDbDecoder]: DynamoDbDecoder[Option[A]] =
+    DynamoDbDecoder.instance { av =>
+      if (Option(av.nul()).map(_.booleanValue()).getOrElse(false)) {
+        none[A].asRight[DecoderFailure]
+      } else {
+        DynamoDbDecoder[A].read(av).map(_.some)
+      }
+    }
+
+  implicit val dynamoDecoderForString: DynamoDbDecoder[String] = DynamoDbDecoder.instance { av =>
+    Option(av.s()).toRight(new DecoderFailure(s"The attribute value must be an S"))
+  }
+
+  implicit val dynamoDecoderForBoolean: DynamoDbDecoder[Boolean] = DynamoDbDecoder.instance { av =>
+    Option(av.bool()).map(_.booleanValue()).toRight(new DecoderFailure(s"The attribute value must be an B"))
+  }
+
+  implicit val dynamoDecoderForLong: DynamoDbDecoder[Long] = DynamoDbDecoder.instance { av =>
+    Option(av.n())
+      .toRight(new DecoderFailure(s"The attribute value must be an N"))
+      .flatMap(n => Either.catchNonFatal(n.toLong).leftMap(e => DecoderFailure(e.getMessage(), e.some)))
+  }
+
+  implicit val dynamoDecoderForInt: DynamoDbDecoder[Int] = DynamoDbDecoder.instance { av =>
+    Option(av.n())
+      .toRight(new DecoderFailure(s"The attribute value must be an N"))
+      .flatMap(n => Either.catchNonFatal(n.toInt).leftMap(e => DecoderFailure(e.getMessage(), e.some)))
+  }
+
+  implicit val dynamoDecoderForInstant: DynamoDbDecoder[Instant] = dynamoDecoderForLong.flatMap { ms =>
+    Either.catchNonFatal(Instant.ofEpochMilli(ms)).fold(
+      e => DynamoDbDecoder.failed(DecoderFailure(e.getMessage(), e.some)),
+      ok => DynamoDbDecoder.const(ok)
+    )
+  }
+
+  implicit def dynamoDecoderForMap[A: DynamoDbDecoder]: DynamoDbDecoder[Map[String, A]] = instance { av =>
+    if(av.hasM()) {
+      av.m().asScala.map { case (k, v) =>
+        (k, DynamoDbDecoder[A].read(v))
+      }.foldLeft(Map.empty[String, A].asRight[DecoderFailure]){(fs, fx) =>
+        for {
+          s <- fs
+          x <- fx._2
+        } yield s + (fx._1 -> x)
+      }
+    } else {
+      DecoderFailure("The AttributeValue must be an M").asLeft[Map[String, A]]
+    }
+  }
+
+}
+

--- a/src/main/scala/deduplication/dynamodb/DynamoDbEncoder.scala
+++ b/src/main/scala/deduplication/dynamodb/DynamoDbEncoder.scala
@@ -1,0 +1,54 @@
+package com.ovoenergy.comms.deduplication
+package dynamodb
+
+import java.time.Instant
+
+import cats._
+import cats.implicits._
+
+import software.amazon.awssdk.services.dynamodb.model._
+
+trait DynamoDbEncoder[A] {
+  def write(a: A): AttributeValue
+}
+
+object DynamoDbEncoder {
+  def apply[A](implicit dd: DynamoDbEncoder[A]): DynamoDbEncoder[A] = dd
+
+  def instance[A](f: A => AttributeValue): DynamoDbEncoder[A] = new DynamoDbEncoder[A] {
+    def write(a: A): AttributeValue = f(a)
+  }
+
+  def const[A](av: AttributeValue): DynamoDbEncoder[A] = new DynamoDbEncoder[A] {
+    def write(a: A): AttributeValue = av
+  }
+
+  implicit def contravariantForDynamoDbDecoder: Contravariant[DynamoDbEncoder] =
+    new Contravariant[DynamoDbEncoder] {
+      def contramap[A, B](fa: DynamoDbEncoder[A])(f: B => A): DynamoDbEncoder[B] =
+        new DynamoDbEncoder[B] {
+          def write(b: B): AttributeValue = fa.write(f(b))
+        }
+    }
+
+  implicit def dynamoEncoderForOption[A: DynamoDbEncoder]: DynamoDbEncoder[Option[A]] =
+    DynamoDbEncoder.instance { fa =>
+      fa.fold(AttributeValue.builder().nul(true).build())(DynamoDbEncoder[A].write)
+    }
+
+  implicit val dynamoEncoderForBoolean: DynamoDbEncoder[Boolean] =
+    DynamoDbEncoder.instance(bool => AttributeValue.builder().bool(bool).build())
+
+  implicit val dynamoEncoderForString: DynamoDbEncoder[String] =
+    DynamoDbEncoder.instance(str => AttributeValue.builder().s(str).build())
+
+  implicit val dynamoEncoderForLong: DynamoDbEncoder[Long] =
+    DynamoDbEncoder.instance(long => AttributeValue.builder().n(long.toString).build())
+
+  implicit val dynamoEncoderForInt: DynamoDbEncoder[Int] =
+    DynamoDbEncoder.instance(int => AttributeValue.builder().n(int.toString).build())
+
+  implicit val dynamoEncoderForInstant: DynamoDbEncoder[Instant] =
+    dynamoEncoderForLong.contramap(instant => instant.toEpochMilli())
+
+}

--- a/src/main/scala/deduplication/dynamodb/DynamoDbEncoder.scala
+++ b/src/main/scala/deduplication/dynamodb/DynamoDbEncoder.scala
@@ -1,6 +1,7 @@
 package com.ovoenergy.comms.deduplication
 package dynamodb
 
+import java.{util => ju}
 import java.time.Instant
 
 import cats._
@@ -41,6 +42,9 @@ object DynamoDbEncoder {
 
   implicit val dynamoEncoderForString: DynamoDbEncoder[String] =
     DynamoDbEncoder.instance(str => AttributeValue.builder().s(str).build())
+
+  implicit val dynamoEncoderForUUID: DynamoDbEncoder[ju.UUID] =
+    DynamoDbEncoder[String].contramap(_.toString)
 
   implicit val dynamoEncoderForLong: DynamoDbEncoder[Long] =
     DynamoDbEncoder.instance(long => AttributeValue.builder().n(long.toString).build())

--- a/src/main/scala/deduplication/dynamodb/DynamoDbProcessRepo.scala
+++ b/src/main/scala/deduplication/dynamodb/DynamoDbProcessRepo.scala
@@ -1,0 +1,177 @@
+package com.ovoenergy.comms.deduplication
+package dynamodb
+
+import java.time.Instant
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
+import scala.compat.java8.DurationConverters._
+
+import cats.implicits._
+import cats.effect._
+import cats.effect.implicits._
+
+import software.amazon.awssdk.services.dynamodb.model._
+import software.amazon.awssdk.services.dynamodb._
+
+import com.ovoenergy.comms.deduplication.model._
+
+object DynamoDbProcessRepo {
+
+  case class Config(tableName: Config.TableName, modifyClientBuilder: DynamoDbAsyncClientBuilder => DynamoDbAsyncClientBuilder = identity)
+
+  object Config {
+    case class TableName(value: String)
+  }
+
+  implicit class RichAttributeValue(av: AttributeValue) {
+    def get[A: DynamoDbDecoder](key: String): Either[DecoderFailure, A] =
+      for {
+        xs <- DynamoDbDecoder[Map[String, AttributeValue]].read(av)
+        x <- DynamoDbDecoder[A].read(xs.getOrElse(key, AttributeValue.builder().nul(true).build()))
+      } yield x
+  }
+
+  implicit val dynamoDbDecoderForExpiration: DynamoDbDecoder[Expiration] =
+    DynamoDbDecoder[Long].flatMap { seconds =>
+      DynamoDbDecoder
+        .instance[Instant] { _ =>
+          Either
+            .catchNonFatal(Instant.ofEpochSecond(seconds))
+            .leftMap(e => DecoderFailure(e.getMessage(), e.some))
+        }
+        .map(Expiration(_))
+    }
+
+  private object field {
+    val id = "id"
+    val processorId = "processorId"
+    val startedAt = "startedAt"
+    val completedAt = "completedAt"
+    val expiresOn = "expiresOn"
+  }
+
+  def resource[F[_]: Async: ContextShift: Timer, ID: DynamoDbDecoder: DynamoDbEncoder, ProcessorID: DynamoDbDecoder: DynamoDbEncoder](
+    config: Config,
+  ): Resource[F, ProcessRepo[F, ID, ProcessorID]] = {
+    Resource.make(Sync[F].delay(config.modifyClientBuilder(DynamoDbAsyncClient.builder()).build())){client => 
+      Sync[F].delay(client.close())
+    }.map(client => apply(config, client))
+  }
+
+  def apply[F[_]: Async: ContextShift: Timer, ID: DynamoDbDecoder: DynamoDbEncoder, ProcessorID: DynamoDbDecoder: DynamoDbEncoder](
+      config: Config,
+      client: DynamoDbAsyncClient
+  ): ProcessRepo[F, ID, ProcessorID] = {
+
+    def update(request: UpdateItemRequest) = {
+      Async[F]
+        .async[UpdateItemResponse] { cb =>
+          client.updateItem(request).handle { (ok, error) =>
+            cb(Option(error).toLeft(ok))
+          }
+
+          ()
+        }
+        .guarantee(ContextShift[F].shift)
+    }
+
+    def readProcess(
+        attributes: AttributeValue
+    ): Either[DecoderFailure, Process[ID, ProcessorID]] =
+      for {
+        id <- attributes.get[ID](field.id)
+        processorId <- attributes.get[ProcessorID](field.processorId)
+        startedAt <- attributes.get[Instant](field.startedAt)
+        completedAt <- attributes.get[Option[Instant]](field.completedAt)
+        expiresOn <- attributes.get[Option[Expiration]](field.expiresOn)
+      } yield Process(
+        id,
+        processorId,
+        startedAt,
+        completedAt,
+        expiresOn
+      )
+
+    new ProcessRepo[F, ID, ProcessorID] {
+
+      def startProcessingUpdate(
+          id: ID,
+          processorId: ProcessorID,
+          now: Instant
+      ): F[Option[Process[ID, ProcessorID]]] = {
+
+        val startedAtVar = ":startedAt"
+
+        val request = UpdateItemRequest
+          .builder()
+          .tableName(config.tableName.value)
+          .key(
+            Map(
+              field.id -> DynamoDbEncoder[ID].write(id),
+              field.processorId -> DynamoDbEncoder[ProcessorID].write(processorId)
+            ).asJava
+          )
+          .updateExpression(
+            s"SET ${field.startedAt} = if_not_exists(${field.startedAt}, ${startedAtVar})"
+          )
+          .expressionAttributeValues(
+            Map(
+              startedAtVar -> AttributeValue.builder().n(now.toEpochMilli().toString).build()
+            ).asJava
+          )
+          .returnValues(ReturnValue.ALL_OLD)
+          .build()
+
+        update(request).map { res =>
+          Option(res.attributes())
+            .filter(_.size > 0)
+            .map(xs => AttributeValue.builder().m(xs).build())
+            .traverse(readProcess)
+        }.rethrow
+      }
+
+      def completeProcess(
+          id: ID,
+          processorId: ProcessorID,
+          now: Instant,
+          ttl: FiniteDuration,
+      ): F[Unit] = {
+        val completedAtVar = ":completedAt"
+        val expiresOnVar = ":expiresOn"
+
+        val request = UpdateItemRequest
+          .builder()
+          .tableName(config.tableName.value)
+          .key(
+            Map(
+              field.id -> DynamoDbEncoder[ID].write(id),
+              field.processorId -> DynamoDbEncoder[ProcessorID].write(processorId)
+            ).asJava
+          )
+          .updateExpression(
+            s"SET ${field.completedAt}=${completedAtVar}, ${field.expiresOn}=${expiresOnVar}"
+          )
+          .expressionAttributeValues(
+            Map(
+              completedAtVar -> AttributeValue
+                .builder()
+                .n(now.toEpochMilli().toString)
+                .build(),
+              expiresOnVar -> AttributeValue
+                .builder()
+                .n(now.plus(ttl.toJava).getEpochSecond().toString)
+                .build()
+            ).asJava
+          )
+          .returnValues(ReturnValue.NONE)
+          .build()
+
+        update(request).void
+      }
+
+    }
+
+  }
+
+}

--- a/src/main/scala/deduplication/model.scala
+++ b/src/main/scala/deduplication/model.scala
@@ -19,9 +19,10 @@ object model {
   sealed trait ProcessStatus
   object ProcessStatus {
     case object NotStarted extends ProcessStatus
-    case object Started extends ProcessStatus
+    case object Running extends ProcessStatus
     case object Completed extends ProcessStatus
     case object Timeout extends ProcessStatus
+    case object Expired extends ProcessStatus
   }
 
   case class Expiration(instant: Instant)

--- a/src/test/scala/deduplication/DeduplicationSuite.scala
+++ b/src/test/scala/deduplication/DeduplicationSuite.scala
@@ -1,151 +1,122 @@
 package com.ovoenergy.comms.deduplication
 
-import java.{util => ju}
 import java.time.Instant
+import java.{util => ju}
+import java.util.UUID
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 import cats.implicits._
+import cats.effect._
+import cats.effect.laws.util.TestContext
 
-import org.scalacheck.Prop._
+import munit._
+import org.scalacheck.Arbitrary
 
 import model._
-import Generators._
+import Config._
 
-class DeduplicationSuite extends munit.ScalaCheckSuite {
+class DeduplicationSuite extends FunSuite {
 
-  property(
-    "processStatus should return Completed if the completedAt is present and expiredOn is None"
-  ) {
-    forAll { process: Process[ju.UUID, ju.UUID] =>
+  private val testContext = TestContext()
 
-      val now = Instant.now()
-      val maxProcessingTime = 5.minutes
+  implicit val ec: ExecutionContext = testContext
+  implicit val contextShift: ContextShift[IO] = testContext.ioContextShift
+  implicit val timer: Timer[IO] = testContext.ioTimer
 
-      val sample = process.copy(
-        completedAt = now.some,
-        expiresOn = None
-      )
+  override def munitValueTransforms = super.munitValueTransforms ++ List(
+    new ValueTransform("IO", {
+      case io: IO[_] => io.unsafeToFuture()
+    })
+  )
 
-      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+  def given[A: Arbitrary]: A = Arbitrary.arbitrary[A].sample.get
 
-      assertEquals(clue(status), ProcessStatus.Completed)
-    }
+  class MockProcessRepo extends ProcessRepo[IO, UUID, UUID] {
+    def startProcessingUpdate(
+        id: UUID,
+        processorId: ju.UUID,
+        now: Instant
+    ): IO[Option[Process[UUID, UUID]]] = none[Process[UUID, UUID]].pure[IO]
+    def completeProcess(id: UUID, processorId: UUID, now: Instant, ttl: FiniteDuration): IO[Unit] =
+      IO.unit
   }
 
-  property(
-    "processStatus should return Completed if the completedAt is present and expiredOn is in the future"
+  test(
+    "tryStartProcess should return New when the process with the given ID has never started before"
   ) {
-    forAll { process: Process[ju.UUID, ju.UUID] =>
 
-      val now = Instant.now()
-      val maxProcessingTime = 5.minutes
+    val processId = given[UUID]
+    val processorId = given[UUID]
 
-      val sample = process.copy(
-        completedAt = now.some,
-        expiresOn = Expiration(now.plusMillis(1)).some
+    val deduplication = Deduplication[IO, UUID, UUID](
+      new MockProcessRepo {
+        override def startProcessingUpdate(
+            id: UUID,
+            processorId: ju.UUID,
+            now: Instant
+        ): IO[Option[Process[UUID, UUID]]] = none[Process[UUID, UUID]].pure[IO]
+      },
+      Config(
+        processorId = processorId,
+        maxProcessingTime = 5.minutes,
+        ttl = 30.days,
+        pollStrategy = PollStrategy.linear()
       )
+    )
 
-      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+    deduplication
+      .flatMap { deduplication =>
+        deduplication.tryStartProcess(processId)
+      }
+      .map { outcome =>
+        assert(outcome.isInstanceOf[Outcome.New[IO]], clue(outcome))
+      }
 
-      assertEquals(clue(status), ProcessStatus.Completed)
-    }
   }
 
-  property("processStatus should return Expired if the expiresOn is present and it is in the past") {
-    forAll { process: Process[ju.UUID, ju.UUID] =>
-
-      val now = Instant.now()
-      val maxProcessingTime = 5.minutes
-
-      val sample = process.copy(
-        expiresOn = Expiration(now.minusMillis(1)).some
-      )
-
-      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
-
-      assertEquals(clue(status), ProcessStatus.Expired)
-    }
-  }
-
-  property(
-    "processStatus should return Timeout if startedAt is more than maxProcessingTime in the past, completedAt and expiresOn are None"
+  test(
+    "tryStartProcess should return Duplicate when the process with the given ID has already completed"
   ) {
-    forAll { process: Process[ju.UUID, ju.UUID] =>
 
-      val now = Instant.now()
-      val maxProcessingTime = 5.minutes
+    val processId = given[UUID]
+    val processorId = given[UUID]
 
-      val sample = process.copy(
-        startedAt = now.minusMillis(maxProcessingTime.toMillis).minusMillis(1),
-        completedAt = None,
-        expiresOn = None
+    val deduplication = Deduplication[IO, UUID, UUID](
+      new MockProcessRepo {
+        override def startProcessingUpdate(
+            id: UUID,
+            processorId: ju.UUID,
+            now: Instant
+        ): IO[Option[Process[UUID, UUID]]] = {
+          Deduplication.nowF[IO].map { now =>
+            Process(
+              id = id,
+              processorId = processorId,
+              startedAt = now.minusMillis(750),
+              completedAt = now.minusMillis(250).some,
+              expiresOn = None
+            ).some
+          }
+
+        }
+      },
+      Config(
+        processorId = processorId,
+        maxProcessingTime = 5.minutes,
+        ttl = 30.days,
+        pollStrategy = PollStrategy.linear()
       )
+    )
 
-      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
-
-      assertEquals(clue(status), ProcessStatus.Timeout)
-    }
-  }
-
-  property(
-    "processStatus should return Timeout if startedAt is more than maxProcessingTime in the past, expiresOn is in the future and completedAt is None"
-  ) {
-    forAll { process: Process[ju.UUID, ju.UUID] =>
-
-      val now = Instant.now()
-      val maxProcessingTime = 5.minutes
-
-      val sample = process.copy(
-        startedAt = now.minusMillis(maxProcessingTime.toMillis).minusMillis(1),
-        completedAt = None,
-        expiresOn = Expiration(now.plusMillis(1)).some
-      )
-
-      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
-
-      assertEquals(clue(status), ProcessStatus.Timeout)
-    }
-  }
-
-  property(
-    "processStatus returns running if startedAt is less than maxProcessingTime in the past, completedAt and expiresOn are None"
-  ) {
-    forAll { process: Process[ju.UUID, ju.UUID] =>
-
-      val now = Instant.now()
-      val maxProcessingTime = 5.minutes
-
-      val sample = process.copy(
-        startedAt = now.minusMillis(maxProcessingTime.toMillis).plusMillis(1),
-        completedAt = None,
-        expiresOn = None
-      )
-
-      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
-
-      assertEquals(clue(status), ProcessStatus.Running)
-    }
-  }
-
-  property(
-    "processStatus returns running if startedAt is less than maxProcessingTime in the past,  expiresOn is in the future and completedAt is None"
-  ) {
-    forAll { process: Process[ju.UUID, ju.UUID] =>
-
-      val now = Instant.now()
-      val maxProcessingTime = 5.minutes
-
-      val sample = process.copy(
-        startedAt = now.minusMillis(maxProcessingTime.toMillis).plusMillis(1),
-        completedAt = None,
-        expiresOn = Expiration(now.plusMillis(1)).some
-      )
-
-      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
-
-      assertEquals(clue(status), ProcessStatus.Running)
-    }
+    deduplication
+      .flatMap { deduplication =>
+        deduplication.tryStartProcess(processId)
+      }
+      .map { outcome =>
+        assertEquals(outcome, Outcome.Duplicate[IO]())
+      }
   }
 
 }

--- a/src/test/scala/deduplication/DeduplicationSuite.scala
+++ b/src/test/scala/deduplication/DeduplicationSuite.scala
@@ -1,0 +1,151 @@
+package com.ovoenergy.comms.deduplication
+
+import java.{util => ju}
+import java.time.Instant
+
+import scala.concurrent.duration._
+
+import cats.implicits._
+
+import org.scalacheck.Prop._
+
+import model._
+import Generators._
+
+class DeduplicationSuite extends munit.ScalaCheckSuite {
+
+  property(
+    "processStatus should return Completed if the completedAt is present and expiredOn is None"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        completedAt = now.some,
+        expiresOn = None
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Completed)
+    }
+  }
+
+  property(
+    "processStatus should return Completed if the completedAt is present and expiredOn is in the future"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        completedAt = now.some,
+        expiresOn = Expiration(now.plusMillis(1)).some
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Completed)
+    }
+  }
+
+  property("processStatus should return Expired if the expiresOn is present and it is in the past") {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        expiresOn = Expiration(now.minusMillis(1)).some
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Expired)
+    }
+  }
+
+  property(
+    "processStatus should return Timeout if startedAt is more than maxProcessingTime in the past, completedAt and expiresOn are None"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        startedAt = now.minusMillis(maxProcessingTime.toMillis).minusMillis(1),
+        completedAt = None,
+        expiresOn = None
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Timeout)
+    }
+  }
+
+  property(
+    "processStatus should return Timeout if startedAt is more than maxProcessingTime in the past, expiresOn is in the future and completedAt is None"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        startedAt = now.minusMillis(maxProcessingTime.toMillis).minusMillis(1),
+        completedAt = None,
+        expiresOn = Expiration(now.plusMillis(1)).some
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Timeout)
+    }
+  }
+
+  property(
+    "processStatus returns running if startedAt is less than maxProcessingTime in the past, completedAt and expiresOn are None"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        startedAt = now.minusMillis(maxProcessingTime.toMillis).plusMillis(1),
+        completedAt = None,
+        expiresOn = None
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Running)
+    }
+  }
+
+  property(
+    "processStatus returns running if startedAt is less than maxProcessingTime in the past,  expiresOn is in the future and completedAt is None"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        startedAt = now.minusMillis(maxProcessingTime.toMillis).plusMillis(1),
+        completedAt = None,
+        expiresOn = Expiration(now.plusMillis(1)).some
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Running)
+    }
+  }
+
+}

--- a/src/test/scala/deduplication/Generators.scala
+++ b/src/test/scala/deduplication/Generators.scala
@@ -1,0 +1,48 @@
+package com.ovoenergy.comms.deduplication
+
+import java.time.Instant
+
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+
+import model._
+import java.time.temporal.ChronoUnit
+
+object Generators {
+
+  implicit val genForInstant: Gen[Instant] = for {
+    ms <- Gen.posNum[Long]
+  } yield Instant.ofEpochMilli(ms)
+
+  implicit val genForExpiration: Gen[Expiration] = for {
+    instant <- arbitrary[Instant]
+  } yield Expiration(instant)
+
+  implicit def genForProcess[Id: Arbitrary, ProcessorId: Arbitrary]: Gen[Process[Id, ProcessorId]] =
+    for {
+      id <- arbitrary[Id]
+      processorId <- arbitrary[ProcessorId]
+      startedAt <- arbitrary[Instant]
+      completedAt <- Gen.option(Gen.choose(500, 5000).map(n => startedAt.plusMillis(n)))
+      expiresOn <- Gen.option(
+        Gen.choose(7, 90).map(n => startedAt.plus(n, ChronoUnit.DAYS)).map(Expiration(_))
+      )
+    } yield Process[Id, ProcessorId](
+      id = id,
+      processorId = processorId,
+      startedAt = startedAt,
+      completedAt = completedAt,
+      expiresOn = expiresOn
+    )
+
+  implicit def genForProcessStatus: Gen[ProcessStatus] = Gen.oneOf(
+    ProcessStatus.Completed,
+    ProcessStatus.Expired,
+    ProcessStatus.NotStarted,
+    ProcessStatus.Running,
+    ProcessStatus.Timeout
+  )
+
+  implicit def arbForGen[A](implicit gen: Gen[A]): Arbitrary[A] = Arbitrary(gen)
+}

--- a/src/test/scala/deduplication/ProcessStatusSuite.scala
+++ b/src/test/scala/deduplication/ProcessStatusSuite.scala
@@ -1,0 +1,152 @@
+package com.ovoenergy.comms.deduplication
+
+import java.{util => ju}
+import java.time.Instant
+
+import scala.concurrent.duration._
+
+import cats.implicits._
+import cats.effect._
+import cats.effect.laws.util._
+
+import org.scalacheck.Prop._
+
+import model._
+import Generators._
+
+class ProcessStatusSuite extends munit.ScalaCheckSuite {
+
+  property(
+    "processStatus should return Completed if the completedAt is present and expiredOn is None"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        completedAt = now.some,
+        expiresOn = None
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Completed)
+    }
+  }
+
+  property(
+    "processStatus should return Completed if the completedAt is present and expiredOn is in the future"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        completedAt = now.some,
+        expiresOn = Expiration(now.plusMillis(1)).some
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Completed)
+    }
+  }
+
+  property("processStatus should return Expired if the expiresOn is present and it is in the past") {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        expiresOn = Expiration(now.minusMillis(1)).some
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Expired)
+    }
+  }
+
+  property(
+    "processStatus should return Timeout if startedAt is more than maxProcessingTime in the past, completedAt and expiresOn are None"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        startedAt = now.minusMillis(maxProcessingTime.toMillis).minusMillis(1),
+        completedAt = None,
+        expiresOn = None
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Timeout)
+    }
+  }
+
+  property(
+    "processStatus should return Timeout if startedAt is more than maxProcessingTime in the past, expiresOn is in the future and completedAt is None"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        startedAt = now.minusMillis(maxProcessingTime.toMillis).minusMillis(1),
+        completedAt = None,
+        expiresOn = Expiration(now.plusMillis(1)).some
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Timeout)
+    }
+  }
+
+  property(
+    "processStatus returns running if startedAt is less than maxProcessingTime in the past, completedAt and expiresOn are None"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        startedAt = now.minusMillis(maxProcessingTime.toMillis).plusMillis(1),
+        completedAt = None,
+        expiresOn = None
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Running)
+    }
+  }
+
+  property(
+    "processStatus returns running if startedAt is less than maxProcessingTime in the past,  expiresOn is in the future and completedAt is None"
+  ) {
+    forAll { process: Process[ju.UUID, ju.UUID] =>
+
+      val now = Instant.now()
+      val maxProcessingTime = 5.minutes
+
+      val sample = process.copy(
+        startedAt = now.minusMillis(maxProcessingTime.toMillis).plusMillis(1),
+        completedAt = None,
+        expiresOn = Expiration(now.plusMillis(1)).some
+      )
+
+      val status = Deduplication.processStatus(maxProcessingTime, now)(sample)
+
+      assertEquals(clue(status), ProcessStatus.Running)
+    }
+  }
+}

--- a/src/test/scala/deduplication/dynamodb/DynamoDbCodecSpec.scala
+++ b/src/test/scala/deduplication/dynamodb/DynamoDbCodecSpec.scala
@@ -1,0 +1,62 @@
+package com.ovoenergy.comms.deduplication
+package dynamodb
+
+import java.{util => ju}
+import java.time.Instant
+import scala.reflect.ClassTag
+
+import cats.implicits._
+
+import software.amazon.awssdk.services.dynamodb.model._
+
+import org.scalacheck.Gen
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+
+class DynamoDbCodecSuite extends munit.ScalaCheckSuite {
+
+  implicit val genForInstant: Gen[Instant] = for {
+    ms <- Gen.posNum[Long]
+  } yield Instant.ofEpochMilli(ms)
+
+  implicit def arbForGen[A](implicit gen: Gen[A]): Arbitrary[A] = Arbitrary(gen)
+
+  checkEncode[String](str => AttributeValue.builder().s(str).build())
+  checkEncodeDecode[String]
+
+  checkEncode[Int](int => AttributeValue.builder().n(s"$int").build())
+  checkEncodeDecode[Int]
+
+  checkEncode[Long](long => AttributeValue.builder().n(s"$long").build())
+  checkEncodeDecode[Long]
+
+  checkEncode[ju.UUID](uuid => AttributeValue.builder().s(uuid.toString).build())
+  checkEncodeDecode[ju.UUID]
+
+  checkEncode[Instant](instant => AttributeValue.builder().n(s"${instant.toEpochMilli()}").build())
+  checkEncodeDecode[Instant]
+
+  def checkEncode[T: Arbitrary: DynamoDbEncoder](
+      expected: T => AttributeValue
+  )(implicit loc: munit.Location, classTag: ClassTag[T]): Unit = {
+    property(s"should encode ${classTag.runtimeClass}") {
+      forAll { t: T =>
+        val result = DynamoDbEncoder[T].write(t)
+        assertEquals(result, expected(t))
+      }
+    }
+  }
+
+  def checkEncodeDecode[T: Arbitrary: DynamoDbEncoder: DynamoDbDecoder](
+      implicit loc: munit.Location,
+      classTag: ClassTag[T]
+  ): Unit = {
+    property(s"should encode/decode ${classTag.runtimeClass}") {
+      forAll { t: T =>
+        val result = DynamoDbDecoder[T].read(DynamoDbEncoder[T].write(t))
+        assertEquals(result, Right(t))
+      }
+    }
+  }
+
+}

--- a/src/test/scala/deduplication/dynamodb/DynamoDbCodecSuite.scala
+++ b/src/test/scala/deduplication/dynamodb/DynamoDbCodecSuite.scala
@@ -13,13 +13,9 @@ import org.scalacheck.Gen
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 
+import Generators._
+
 class DynamoDbCodecSuite extends munit.ScalaCheckSuite {
-
-  implicit val genForInstant: Gen[Instant] = for {
-    ms <- Gen.posNum[Long]
-  } yield Instant.ofEpochMilli(ms)
-
-  implicit def arbForGen[A](implicit gen: Gen[A]): Arbitrary[A] = Arbitrary(gen)
 
   checkEncode[String](str => AttributeValue.builder().s(str).build())
   checkEncodeDecode[String]


### PR DESCRIPTION
This is a full rewrite. It splits up the deduplication from the dynamo DB part to make the logic easier to understand and to in future support other backends.

It moves to AWS sdkv2., and introduce a DynamoDb Encoder/Decoder similar to circe.

It also replaces scalatest with munit.

