### PR TITLE
Avoid using phil-processing table in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ val catsVersion = "2.2.0"
 val catsEffectVersion = "2.2.0"
 val slf4jVersion = "1.7.30"
 val scalaJava8CompatVersion = "0.9.1"
-val awsSdkVersion = "2.15.12"
+val awsSdkVersion = "2.15.35"
 val log4CatsVersion = "1.1.1"
-val munitVersion = "0.7.14"
+val munitVersion = "0.7.19"
 val logBackVersion = "1.2.3"
 
 lazy val deduplication = (project in file("."))
@@ -15,14 +15,14 @@ lazy val deduplication = (project in file("."))
     organization := "com.ovoenergy.comms",
     organizationHomepage := Some(url("http://www.ovoenergy.com")),
     licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
-    scalaVersion := "2.13.1",
-    crossScalaVersions += "2.12.11",
+    scalaVersion := "2.13.4",
+    crossScalaVersions += "2.12.12",
     scalafmtOnCompile := true,
     scalacOptions -= "-Xfatal-warnings", // enable all options from sbt-tpolecat except fatal warnings
     initialCommands := s"import com.ovoenergy.comms.deduplication._",
     javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation"),
     testFrameworks += new TestFramework("munit.Framework"),
-    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),
+    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.1" cross CrossVersion.full),
     scmInfo := Some(
       ScmInfo(
         url("https://github.com/ovotech/comms-deduplication"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.1
+sbt.version=1.4.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.1")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.14")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.15")

--- a/src/it/resources/logback-test.xml
+++ b/src/it/resources/logback-test.xml
@@ -10,6 +10,7 @@
 
     <logger name="org.apache.http" level="OFF" />
     <logger name="com.amazonaws.auth.profile.internal.BasicProfileConfigLoader" level="OFF" />
+    <logger name="software.amazon.awssdk.profiles.internal.ProfileFileReader" level="OFF" />
     <logger name="com.ovoenergy.comms.deduplication" level="DEBUG" />
 
     <root level="WARN">

--- a/src/it/scala/deduplication/DynamoDbProcessRepoSuite.scala
+++ b/src/it/scala/deduplication/DynamoDbProcessRepoSuite.scala
@@ -1,0 +1,157 @@
+package com.ovoenergy.comms.deduplication
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import java.time.Instant
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+
+import cats.effect._
+import cats.implicits._
+
+import munit._
+import org.scalacheck.Arbitrary
+
+import software.amazon.awssdk.services.dynamodb.{model => _, _}
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse
+
+import com.ovoenergy.comms.deduplication.TestUtils._
+import com.ovoenergy.comms.deduplication.dynamodb.DynamoDbConfig
+import com.ovoenergy.comms.deduplication.dynamodb.DynamoDbProcessRepo
+import com.ovoenergy.comms.deduplication.utils._
+
+class DynamoDbProcessRepoSuite extends FunSuite {
+
+  implicit val ec = ExecutionContext.global
+  implicit val contextShift = IO.contextShift(ec)
+  implicit val timer: Timer[IO] = IO.timer(ec)
+
+  override def munitValueTransforms = super.munitValueTransforms ++ List(
+    new ValueTransform("IO", {
+      case io: IO[_] => io.unsafeToFuture()
+    })
+  )
+
+  def given[A: Arbitrary]: IO[A] =
+    IO.fromOption(Arbitrary.arbitrary[A].sample)(
+      new RuntimeException("Unable to generate a sample")
+    )
+
+  test("startProcessingUpdate should add the record in dynamo") {
+
+    resources.use { resources =>
+
+      for {
+        id <- given[UUID]
+        processorId <- given[UUID]
+        now <- Clock[IO].realTime(TimeUnit.MILLISECONDS).map(Instant.ofEpochMilli)
+        _ <- resources.processRepoR.startProcessingUpdate(
+          id = id,
+          processorId = processorId,
+          now = now
+        )
+        optItem <- resources.getItem(id, processorId)
+      } yield assertEquals(optItem.isDefined, true, clue(optItem))
+    }
+  }
+
+  test("startProcessingUpdate should populate only startedAt when there is not previous record") {
+
+    resources.use { resources =>
+
+      for {
+        id <- given[UUID]
+        processorId <- given[UUID]
+        now <- Clock[IO].realTime(TimeUnit.MILLISECONDS).map(Instant.ofEpochMilli)
+        _ <- resources.processRepoR.startProcessingUpdate(
+          id = id,
+          processorId = processorId,
+          now = now
+        )
+        optItem <- resources.getItem(id, processorId)
+        item <- IO.fromOption(optItem)(new RuntimeException("Item not found"))
+      } yield {
+
+        val testeeStartedAt = Option(item.m)
+          .flatMap { m =>
+            Option(m.get(DynamoDbProcessRepo.field.startedAt))
+          }
+          .flatMap { id =>
+            Option(id.n())
+          }
+          .map { n =>
+            Instant.ofEpochMilli(n.toLong)
+          }
+
+        assertEquals(clue(testeeStartedAt), now.some, clue(item))
+
+        val testeeCompletedAt = Option(item.m)
+          .flatMap { m =>
+            Option(m.get(DynamoDbProcessRepo.field.completedAt))
+          }
+
+        assertEquals(clue(testeeCompletedAt), None, clue(item))
+
+        val testeeExpiredOn = Option(item.m)
+          .flatMap { m =>
+            Option(m.get(DynamoDbProcessRepo.field.expiresOn))
+          }
+
+        assertEquals(clue(testeeExpiredOn), None, clue(item))
+      }
+    }
+  }
+
+  case class Resources(
+      config: DynamoDbConfig,
+      dynamoclient: DynamoDbAsyncClient,
+      processRepoR: ProcessRepo[IO, UUID, UUID]
+  ) {
+
+    def getItem(id: UUID, processorId: UUID): IO[Option[AttributeValue]] = {
+      val request = GetItemRequest
+        .builder()
+        .tableName(config.tableName.value)
+        .key(
+          Map(
+            "id" -> AttributeValue.builder.s(id.toString()).build(),
+            "processorId" -> AttributeValue.builder.s(processorId.toString()).build()
+          ).asJava
+        )
+        .consistentRead(true)
+        .build()
+
+      val response = fromCompletableFuture[IO, GetItemResponse] { () =>
+        dynamoclient
+          .getItem(request)
+      }
+
+      response.map { r =>
+        if (r.hasItem()) {
+          AttributeValue.builder().m(r.item).build.some
+        } else {
+          none[AttributeValue]
+        }
+      }
+    }
+
+  }
+
+  val resources: Resource[IO, Resources] = for {
+    dynamoClient <- dynamoClientResource[IO]
+    tableName <- Resource.liftF(randomTableName[IO])
+    table <- tableResource[IO](dynamoClient, tableName)
+    config = DynamoDbConfig(DynamoDbConfig.TableName(table))
+  } yield Resources(
+    config,
+    dynamoClient,
+    DynamoDbProcessRepo[IO, UUID, UUID](
+      config,
+      dynamoClient
+    )
+  )
+}

--- a/src/it/scala/deduplication/TestUtils.scala
+++ b/src/it/scala/deduplication/TestUtils.scala
@@ -1,0 +1,117 @@
+package com.ovoenergy.comms.deduplication
+
+import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
+import scala.concurrent.duration._
+
+import java.util.UUID
+
+import cats._
+import cats.effect._
+import cats.implicits._
+
+import software.amazon.awssdk.services.dynamodb.model._
+import software.amazon.awssdk.services.dynamodb.{model => _, _}
+
+import com.ovoenergy.comms.deduplication.dynamodb._
+import com.ovoenergy.comms.deduplication.utils._
+
+package object TestUtils {
+
+  def processRepoResource[F[_]: Concurrent: ContextShift: Timer]
+      : Resource[F, ProcessRepo[F, UUID, UUID]] =
+    for {
+      dynamoclient <- dynamoClientResource[F]
+      tableName <- Resource.liftF(randomTableName)
+      table <- tableResource[F](dynamoclient, tableName)
+    } yield DynamoDbProcessRepo[F, UUID, UUID](
+      DynamoDbConfig(DynamoDbConfig.TableName(table)),
+      dynamoclient
+    )
+
+  def tableResource[F[_]: Concurrent: Timer](
+      client: DynamoDbAsyncClient,
+      tableName: String
+  ): Resource[F, String] =
+    Resource.make(createTable(client, tableName))(deleteTable(client, _))
+
+  def createTable[F[_]: Concurrent: Timer](
+      client: DynamoDbAsyncClient,
+      tableName: String
+  ): F[String] = {
+    val createTableRequest =
+      CreateTableRequest
+        .builder()
+        .tableName(tableName)
+        .billingMode(BillingMode.PAY_PER_REQUEST)
+        .keySchema(
+          List(
+            dynamoKey(DynamoDbProcessRepo.field.id, KeyType.HASH),
+            dynamoKey(DynamoDbProcessRepo.field.processorId, KeyType.RANGE)
+          ).asJava
+        )
+        .attributeDefinitions(
+          dynamoAttribute(DynamoDbProcessRepo.field.id, ScalarAttributeType.S),
+          dynamoAttribute(DynamoDbProcessRepo.field.processorId, ScalarAttributeType.S)
+        )
+        .build()
+    fromCompletableFuture[F, CreateTableResponse](() => client.createTable(createTableRequest))
+      .map(_.tableDescription().tableName())
+      .flatTap(waitForTableCreation(client, _))
+      .onError {
+        case NonFatal(e) => Concurrent[F].delay(println(s"Error creating DynamoDb table: $e"))
+      }
+  }
+
+  def deleteTable[F[_]: Concurrent](client: DynamoDbAsyncClient, tableName: String): F[Unit] = {
+    val deleteTableRequest = DeleteTableRequest.builder().tableName(tableName).build()
+    fromCompletableFuture[F, DeleteTableResponse](() => client.deleteTable(deleteTableRequest)).void
+      .onError {
+        case NonFatal(e) => Concurrent[F].delay(println(s"Error creating DynamoDb table: $e"))
+      }
+  }
+
+  def waitForTableCreation[F[_]: Concurrent: Timer](
+      client: DynamoDbAsyncClient,
+      tableName: String,
+      pollEveryMs: FiniteDuration = 100.milliseconds
+  )(implicit ME: MonadError[F, Throwable]): F[Unit] = {
+    val request = DescribeTableRequest.builder().tableName(tableName).build()
+    for {
+      response <- fromCompletableFuture(() => client.describeTable(request))
+      _ <- response.table().tableStatus() match {
+        case TableStatus.ACTIVE => ().pure[F]
+        case TableStatus.CREATING | TableStatus.UPDATING =>
+          Timer[F].sleep(pollEveryMs) >> waitForTableCreation(client, tableName, pollEveryMs)
+        case status =>
+          ME.raiseError(
+            new Exception(s"Unexpected status ${status.toString()} for table ${tableName}")
+          )
+      }
+    } yield ()
+  }
+
+  def dynamoKey(attributeName: String, keyType: KeyType): KeySchemaElement =
+    KeySchemaElement
+      .builder()
+      .attributeName(attributeName)
+      .keyType(keyType)
+      .build()
+
+  def dynamoAttribute(
+      attributeName: String,
+      attributeType: ScalarAttributeType
+  ): AttributeDefinition =
+    AttributeDefinition
+      .builder()
+      .attributeName(attributeName)
+      .attributeType(attributeType)
+      .build()
+
+  def dynamoClientResource[F[_]: Sync]: Resource[F, DynamoDbAsyncClient] =
+    Resource.make(Sync[F].delay(DynamoDbAsyncClient.builder.build()))(c => Sync[F].delay(c.close()))
+
+  def randomTableName[F[_]: Sync]: F[String] =
+    Sync[F].delay(s"comms-deduplication-test-${UUID.randomUUID()}")
+
+}

--- a/src/main/scala/deduplication/dynamodb/DynamoDbProcessRepo.scala
+++ b/src/main/scala/deduplication/dynamodb/DynamoDbProcessRepo.scala
@@ -50,7 +50,7 @@ object DynamoDbProcessRepo {
         .map(Expiration(_))
     }
 
-  private object field {
+  object field {
     val id = "id"
     val processorId = "processorId"
     val startedAt = "startedAt"

--- a/src/main/scala/deduplication/utils.scala
+++ b/src/main/scala/deduplication/utils.scala
@@ -1,0 +1,21 @@
+package com.ovoenergy.comms.deduplication
+
+import java.util.concurrent.CompletableFuture
+
+import cats.effect.Concurrent
+import cats.implicits._
+
+package object utils {
+
+  def fromCompletableFuture[F[_]: Concurrent, A](f: () => CompletableFuture[A]): F[A] =
+    Concurrent[F].cancelable[A] { cb =>
+
+      val future = f()
+      future.whenComplete { (ok, err) =>
+        cb(Option(err).toLeft(ok))
+      }
+
+      Concurrent[F].delay(future.cancel(true)).void
+    }
+
+}


### PR DESCRIPTION
This PR refactor the tests to us a new table each test rather than the previous `phil-processing` table.