### PR TITLE
OMP-176 Add invalidate method, make ttl optional

### DIFF
--- a/src/it/scala/deduplication/DeduplicationSuite.scala
+++ b/src/it/scala/deduplication/DeduplicationSuite.scala
@@ -181,10 +181,10 @@ class DeduplicationSuite extends FunSuite {
       config = Config(
         processorId = processorId,
         maxProcessingTime = maxProcessingTime,
-        ttl = 1.day,
+        ttl = 1.day.some,
         pollStrategy = PollStrategy.backoff(maxDuration = maxPollingTime)
       )
-      deduplication <- Resource.liftF(Deduplication[IO, UUID, UUID](processRepo, config))
+      deduplication <- Resource.eval(Deduplication[IO, UUID, UUID](processRepo, config))
     } yield deduplication
 
 }

--- a/src/it/scala/deduplication/TestUtils.scala
+++ b/src/it/scala/deduplication/TestUtils.scala
@@ -22,7 +22,7 @@ package object TestUtils {
       : Resource[F, ProcessRepo[F, UUID, UUID]] =
     for {
       dynamoclient <- dynamoClientResource[F]
-      tableName <- Resource.liftF(randomTableName)
+      tableName <- Resource.eval(randomTableName)
       table <- tableResource[F](dynamoclient, tableName)
     } yield DynamoDbProcessRepo[F, UUID, UUID](
       DynamoDbConfig(DynamoDbConfig.TableName(table)),

--- a/src/main/scala/deduplication/Config.scala
+++ b/src/main/scala/deduplication/Config.scala
@@ -22,7 +22,7 @@ import Config._
 case class Config[ProcessorID](
     processorId: ProcessorID,
     maxProcessingTime: FiniteDuration,
-    ttl: FiniteDuration,
+    ttl: Option[FiniteDuration],
     pollStrategy: PollStrategy
 )
 

--- a/src/main/scala/deduplication/Deduplication.scala
+++ b/src/main/scala/deduplication/Deduplication.scala
@@ -194,8 +194,10 @@ class Deduplication[F[_]: Sync: Timer, ID, ProcessorID] private (
   /**
     * Invalidate a process.
     *
+    * If the process exists, the record is deleted.
+    *
     * @param id The process id to invalidate
-    * @return Nothing
+    * @return Unit
     */
   def invalidate(id: ID): F[Unit] = {
     repo.invalidateProcess(id, config.processorId).flatTap { _ =>

--- a/src/main/scala/deduplication/Deduplication.scala
+++ b/src/main/scala/deduplication/Deduplication.scala
@@ -190,4 +190,18 @@ class Deduplication[F[_]: Sync: Timer, ID, ProcessorID] private (
           ifDuplicate
       }
   }
+
+  /**
+    * Invalidate a process.
+    *
+    * @param id The process id to invalidate
+    * @return Nothing
+    */
+  def invalidate(id: ID): F[Unit] = {
+    repo.invalidateProcess(id, config.processorId).flatTap { _ =>
+      logger.debug(
+        s"Process invalidated processorId=${config.processorId}, id=$id"
+      )
+    }
+  }
 }

--- a/src/main/scala/deduplication/ProcessRepo.scala
+++ b/src/main/scala/deduplication/ProcessRepo.scala
@@ -17,6 +17,11 @@ trait ProcessRepo[F[_], ID, ProcessorID] {
       id: ID,
       processorId: ProcessorID,
       now: Instant,
-      ttl: FiniteDuration
+      ttl: Option[FiniteDuration]
+  ): F[Unit]
+
+  def invalidateProcess(
+      id: ID,
+      processorId: ProcessorID
   ): F[Unit]
 }

--- a/src/test/scala/deduplication/DeduplicationSuite.scala
+++ b/src/test/scala/deduplication/DeduplicationSuite.scala
@@ -39,8 +39,14 @@ class DeduplicationSuite extends FunSuite {
         processorId: ju.UUID,
         now: Instant
     ): IO[Option[Process[UUID, UUID]]] = none[Process[UUID, UUID]].pure[IO]
-    def completeProcess(id: UUID, processorId: UUID, now: Instant, ttl: FiniteDuration): IO[Unit] =
+    def completeProcess(
+        id: UUID,
+        processorId: UUID,
+        now: Instant,
+        ttl: Option[FiniteDuration]
+    ): IO[Unit] =
       IO.unit
+    def invalidateProcess(id: UUID, processorId: UUID): IO[Unit] = IO.unit
   }
 
   test(
@@ -61,7 +67,7 @@ class DeduplicationSuite extends FunSuite {
       Config(
         processorId = processorId,
         maxProcessingTime = 5.minutes,
-        ttl = 30.days,
+        ttl = 30.days.some,
         pollStrategy = PollStrategy.linear()
       )
     )
@@ -104,7 +110,7 @@ class DeduplicationSuite extends FunSuite {
       Config(
         processorId = processorId,
         maxProcessingTime = 5.minutes,
-        ttl = 30.days,
+        ttl = 30.days.some,
         pollStrategy = PollStrategy.linear()
       )
     )
@@ -146,7 +152,7 @@ class DeduplicationSuite extends FunSuite {
       Config(
         processorId = processorId,
         maxProcessingTime = 5.minutes,
-        ttl = 30.days,
+        ttl = 30.days.some,
         pollStrategy = PollStrategy.linear()
       )
     )
@@ -188,7 +194,7 @@ class DeduplicationSuite extends FunSuite {
       Config(
         processorId = processorId,
         maxProcessingTime = 5.minutes,
-        ttl = 30.days,
+        ttl = 30.days.some,
         pollStrategy = PollStrategy.linear()
       )
     )
@@ -230,7 +236,7 @@ class DeduplicationSuite extends FunSuite {
       Config(
         processorId = processorId,
         maxProcessingTime = 100.seconds,
-        ttl = 30.days,
+        ttl = 30.days.some,
         pollStrategy = PollStrategy.linear()
       )
     )


### PR DESCRIPTION
We were looking to use this library within our team, and were told contributions would be welcome.

Changes:
- Add invalidate method to allow removal of a process record
- Make ttl an optional param in Config, supporting the functionality of non-expiring locks

Use case behind invalidate is that it allows for locks to be removed based on feedback from _very_ async processes