### PR TITLE
Allow for storing Option and Unit as process result

### DIFF
--- a/src/it/scala/deduplication/DeduplicationSuite.scala
+++ b/src/it/scala/deduplication/DeduplicationSuite.scala
@@ -31,13 +31,13 @@ class DeduplicationSuite extends FunSuite {
   }
 
   test(
-    "should be able to tell an non-completed process from a complete one, when the return type is Unit"
+    "should be able to tell a non-completed process from a completed one, when the return type is Unit"
   ) {
     testDeduplication().map(_.context[Unit]("test")).use { dedup =>
       for {
         p1 <- TestProcess[Unit](none, 1.second)
-        p2 <- TestProcess[Unit](().some)
-        p3 <- TestProcess[Unit](().some)
+        p2 <- TestProcess(().some)
+        p3 <- TestProcess(().some)
         _ <- dedup.protect("id", p1.run).attempt
         res2 <- dedup.protect("id", p2.run)
         res3 <- dedup.protect("id", p3.run)
@@ -55,13 +55,13 @@ class DeduplicationSuite extends FunSuite {
   }
 
   test(
-    "should be able to tell an non-completed process from a complete one, when the return type is Optional"
+    "should be able to tell a non-completed process from a completed one, when the return type is Optional"
   ) {
     testDeduplication().map(_.context[Option[String]]("test")).use { dedup =>
       for {
         p1 <- TestProcess[Option[String]](none, 1.second)
         p2 <- TestProcess[Option[String]](none.some)
-        p3 <- TestProcess[Option[String]]("some_result".some.some)
+        p3 <- TestProcess("some_result".some.some)
         _ <- dedup.protect("id", p1.run).attempt
         res2 <- dedup.protect("id", p2.run)
         // the last call to protect should pick up the result from p2 and return none
@@ -98,7 +98,7 @@ class DeduplicationSuite extends FunSuite {
   test("should only allow one process to take over a stale one") {
     testDeduplication().map(_.context[String]("test")).use { dedup =>
       for {
-        fail <- TestProcess(none, 2.seconds)
+        fail <- TestProcess[String](none, 2.seconds)
         _ <- dedup.protect("id", fail.run).attempt.start
         _ <- IO.sleep(500.millis)
         ps <- List.fill(100)(TestProcess("takeover".some)).sequence
@@ -187,7 +187,7 @@ class DeduplicationSuite extends FunSuite {
       .map(_.context[String]("test"))
       .use { dedup =>
         for {
-          halt <- TestProcess(none)
+          halt <- TestProcess[String](none)
           proc <- TestProcess("result".some)
           protect1 <- dedup.protect("id", halt.run).attempt
           protect2 <- dedup.protect("id", proc.run).attempt

--- a/src/it/scala/deduplication/TestUtils.scala
+++ b/src/it/scala/deduplication/TestUtils.scala
@@ -1,6 +1,8 @@
 package com.ovoenergy.comms.deduplication
 
 import _root_.meteor._
+import _root_.meteor.codec.Encoder
+import _root_.meteor.syntax._
 import cats.effect._
 import cats.implicits._
 import com.ovoenergy.comms.deduplication.meteor._
@@ -10,6 +12,7 @@ import scala.concurrent.ExecutionContext
 import software.amazon.awssdk.services.dynamodb.model.BillingMode
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import java.time.Instant
+import com.ovoenergy.comms.deduplication.meteor.model.EncodedResult
 
 object DeduplicationTestUtils {
 
@@ -70,7 +73,7 @@ object DeduplicationTestUtils {
 
   val uuidF = IO(UUID.randomUUID())
 
-  val testRepo: Resource[IO, ProcessRepo[IO, String, String, AttributeValue]] =
+  val testRepo: Resource[IO, ProcessRepo[IO, String, String, EncodedResult]] =
     for {
       uuid <- Resource.eval(uuidF)
       tableName = s"comms-deduplication-test-${uuid}"
@@ -86,7 +89,7 @@ object DeduplicationTestUtils {
       maxProcessingTime: FiniteDuration = 5.seconds,
       ttl: Option[FiniteDuration] = none,
       pollStrategy: Config.PollStrategy = defaultPollStrategy
-  ): Resource[IO, Deduplication[IO, String, String, AttributeValue]] = {
+  ): Resource[IO, Deduplication[IO, String, String, EncodedResult]] = {
     val config = Config(maxProcessingTime, ttl, pollStrategy)
     testRepo.evalMap(Deduplication.apply(_, config))
   }

--- a/src/it/scala/deduplication/meteor/MeteorProcessRepoSuite.scala
+++ b/src/it/scala/deduplication/meteor/MeteorProcessRepoSuite.scala
@@ -3,11 +3,12 @@ package com.ovoenergy.comms.deduplication.meteor
 import cats.effect._
 import cats.implicits._
 import com.ovoenergy.comms.deduplication.DeduplicationTestUtils._
+import com.ovoenergy.comms.deduplication.meteor.model.EncodedResult
 import java.time.Instant
 import java.util.concurrent.TimeUnit
+import meteor.syntax._
 import munit._
 import scala.concurrent.duration._
-import meteor.syntax._
 
 class MeteorProcessRepoSuite extends FunSuite {
 
@@ -25,7 +26,7 @@ class MeteorProcessRepoSuite extends FunSuite {
         contextId2 <- uuidF.map(_.toString())
         now <- Clock[IO].realTime(TimeUnit.MILLISECONDS).map(Instant.ofEpochMilli _)
         later = Instant.ofEpochMilli(now.toEpochMilli() + 1000)
-        testResult = "testresult".asAttributeValue
+        testResult = EncodedResult("testresult".asAttributeValue)
         _ <- repo.create(id, contextId1, now)
         _ <- repo.create(id, contextId2, later)
         _ <- repo.markAsCompleted(id, contextId2, testResult, later, none)
@@ -96,7 +97,7 @@ class MeteorProcessRepoSuite extends FunSuite {
         contextId <- uuidF.map(_.toString())
         now <- Clock[IO].realTime(TimeUnit.MILLISECONDS).map(Instant.ofEpochMilli _)
         later = Instant.ofEpochMilli(now.toEpochMilli() + 1000)
-        testResult = "testresult".asAttributeValue
+        testResult = EncodedResult("testresult".asAttributeValue)
         _ <- repo.create(id, contextId, now)
         _ <- repo.markAsCompleted(id, contextId, testResult, now, 10.seconds.some)
         process <- repo.get(id, contextId)
@@ -116,7 +117,7 @@ class MeteorProcessRepoSuite extends FunSuite {
         contextId <- uuidF.map(_.toString())
         now <- Clock[IO].realTime(TimeUnit.MILLISECONDS).map(Instant.ofEpochMilli _)
         later = Instant.ofEpochMilli(now.toEpochMilli() + 1000)
-        testResult = "testresult".asAttributeValue
+        testResult = EncodedResult("testresult".asAttributeValue)
         _ <- repo.create(id, contextId, now)
         _ <- repo.markAsCompleted(id, contextId, testResult, now, none)
         process <- repo.get(id, contextId)
@@ -138,7 +139,13 @@ class MeteorProcessRepoSuite extends FunSuite {
         now <- Clock[IO].realTime(TimeUnit.MILLISECONDS).map(Instant.ofEpochMilli _)
         later = Instant.ofEpochMilli(now.toEpochMilli() + 1000)
         _ <- repo.create(id, contextId, now)
-        _ <- repo.markAsCompleted(id, contextId, "123".asAttributeValue, now, 30.days.some)
+        _ <- repo.markAsCompleted(
+          id,
+          contextId,
+          EncodedResult("123".asAttributeValue),
+          now,
+          30.days.some
+        )
         _ <- repo.attemptReplacing(id, contextId, now, later)
         process <- repo.get(id, contextId)
       } yield {
@@ -157,7 +164,7 @@ class MeteorProcessRepoSuite extends FunSuite {
         contextId <- uuidF.map(_.toString())
         now <- Clock[IO].realTime(TimeUnit.MILLISECONDS).map(Instant.ofEpochMilli _)
         later = Instant.ofEpochMilli(now.toEpochMilli() + 1000)
-        testResult = "testresult".asAttributeValue
+        testResult = EncodedResult("testresult".asAttributeValue)
         _ <- repo.create(id, contextId, now)
         _ <- repo.markAsCompleted(id, contextId, testResult, now, none)
         _ <- repo.attemptReplacing(id, contextId, later, later)

--- a/src/main/scala/deduplication/meteor/MeteorDeduplication.scala
+++ b/src/main/scala/deduplication/meteor/MeteorDeduplication.scala
@@ -1,10 +1,11 @@
-package com.ovoenergy.comms.deduplication.meteor
+package com.ovoenergy.comms.deduplication
+package meteor
 
-import com.ovoenergy.comms.deduplication.{meteor => _, _}
-import meteor.codec.Codec
-import meteor.CompositeKeysTable
-import meteor.Client
+import _root_.meteor.codec.Codec
+import _root_.meteor.CompositeKeysTable
+import _root_.meteor.Client
 import cats.effect._
+import com.ovoenergy.comms.deduplication.meteor.model._
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 object MeteorDeduplication {
@@ -13,7 +14,7 @@ object MeteorDeduplication {
       client: Client[F],
       table: CompositeKeysTable[ID, ContextID],
       config: Config
-  ): F[Deduplication[F, ID, ContextID, AttributeValue]] =
+  ): F[Deduplication[F, ID, ContextID, EncodedResult]] =
     Deduplication(
       MeteorProcessRepo(client, table, false),
       config
@@ -23,7 +24,7 @@ object MeteorDeduplication {
       client: Client[F],
       table: CompositeKeysTable[ID, ContextID],
       config: Config
-  ): Resource[F, Deduplication[F, ID, ContextID, AttributeValue]] =
-    Resource.eval[F, Deduplication[F, ID, ContextID, AttributeValue]](apply(client, table, config))
+  ): Resource[F, Deduplication[F, ID, ContextID, EncodedResult]] =
+    Resource.eval[F, Deduplication[F, ID, ContextID, EncodedResult]](apply(client, table, config))
 
 }

--- a/src/main/scala/deduplication/meteor/MeteorProcessRepo.scala
+++ b/src/main/scala/deduplication/meteor/MeteorProcessRepo.scala
@@ -1,20 +1,20 @@
-package com.ovoenergy.comms.deduplication.meteor
+package com.ovoenergy.comms.deduplication
+package meteor
 
 import cats.effect._
 import cats.implicits._
 import com.ovoenergy.comms.deduplication.meteor.codecs._
+import com.ovoenergy.comms.deduplication.meteor.model._
 import com.ovoenergy.comms.deduplication.model._
-import com.ovoenergy.comms.deduplication.{meteor => _, _}
 import java.time.Instant
-import meteor.Client
-import meteor.CompositeKeysTable
-import meteor.Expression
-import meteor.codec.Codec
-import meteor.errors
-import meteor.syntax._
+import _root_.meteor.Client
+import _root_.meteor.CompositeKeysTable
+import _root_.meteor.Expression
+import _root_.meteor.codec.Codec
+import _root_.meteor.errors
+import _root_.meteor.syntax._
 import scala.concurrent.duration.FiniteDuration
 import software.amazon.awssdk.services.dynamodb.model.ReturnValue
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 object MeteorProcessRepo {
 
@@ -22,16 +22,16 @@ object MeteorProcessRepo {
       client: Client[F],
       table: CompositeKeysTable[ID, ContextID],
       readConsistently: Boolean = false
-  ): ProcessRepo[F, ID, ContextID, AttributeValue] =
-    new ProcessRepo[F, ID, ContextID, AttributeValue] {
+  ): ProcessRepo[F, ID, ContextID, EncodedResult] =
+    new ProcessRepo[F, ID, ContextID, EncodedResult] {
 
       def create(
           id: ID,
           contextId: ContextID,
           now: Instant
-      ): F[Option[Process[ID, ContextID, AttributeValue]]] =
+      ): F[Option[Process[ID, ContextID, EncodedResult]]] =
         client
-          .update[ID, ContextID, Process[ID, ContextID, AttributeValue]](
+          .update[ID, ContextID, Process[ID, ContextID, EncodedResult]](
             table,
             id,
             contextId,
@@ -46,12 +46,12 @@ object MeteorProcessRepo {
       def markAsCompleted(
           id: ID,
           contextId: ContextID,
-          result: AttributeValue,
+          result: EncodedResult,
           now: Instant,
           ttl: Option[FiniteDuration]
       ): F[Unit] =
         client
-          .update[ID, ContextID, Process[ID, ContextID, AttributeValue]](
+          .update[ID, ContextID, Process[ID, ContextID, EncodedResult]](
             table,
             id,
             contextId,
@@ -75,8 +75,8 @@ object MeteorProcessRepo {
       def get(
           id: ID,
           contextId: ContextID
-      ): F[Option[Process[ID, ContextID, AttributeValue]]] =
-        client.get[ID, ContextID, Process[ID, ContextID, AttributeValue]](
+      ): F[Option[Process[ID, ContextID, EncodedResult]]] =
+        client.get[ID, ContextID, Process[ID, ContextID, EncodedResult]](
           table,
           id,
           contextId,
@@ -90,7 +90,7 @@ object MeteorProcessRepo {
           newStartedAt: Instant
       ): F[ProcessRepo.AttemptResult] =
         client
-          .update[ID, ContextID, Process[ID, ContextID, AttributeValue]](
+          .update[ID, ContextID, Process[ID, ContextID, EncodedResult]](
             table,
             id,
             contextId,

--- a/src/main/scala/deduplication/meteor/codecs.scala
+++ b/src/main/scala/deduplication/meteor/codecs.scala
@@ -44,6 +44,20 @@ package object codecs {
       def write(a: A): Either[Throwable, AttributeValue] = meteorCodec.write(a).asRight[Throwable]
     }
 
+  implicit val UnitResultCodec =
+    new ResultCodec[AttributeValue, Unit] {
+      def read(a: AttributeValue): Either[Throwable, Unit] = ().asRight[Throwable]
+      def write(b: Unit): Either[Throwable, AttributeValue] =
+        AttributeValue.builder().nul(true).build().asRight[Throwable]
+    }
+
+  implicit def OptionResultCodec[A: Codec] =
+    new ResultCodec[AttributeValue, Option[A]] {
+      def read(av: AttributeValue): Either[Throwable, Option[A]] = av.asOpt[A]
+      def write(a: Option[A]): Either[Throwable, AttributeValue] =
+        a.asAttributeValue.asRight[Throwable]
+    }
+
   implicit def ProcessCodec[ID: Codec, ContextID: Codec]
       : Codec[Process[ID, ContextID, AttributeValue]] =
     new Codec[Process[ID, ContextID, AttributeValue]] {

--- a/src/main/scala/deduplication/meteor/model.scala
+++ b/src/main/scala/deduplication/meteor/model.scala
@@ -1,0 +1,6 @@
+package com.ovoenergy.comms.deduplication.meteor
+package model
+
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+
+case class EncodedResult(value: AttributeValue)

--- a/src/test/scala/deduplication/meteor/MeteorCodecSuite.scala
+++ b/src/test/scala/deduplication/meteor/MeteorCodecSuite.scala
@@ -5,6 +5,7 @@ import _root_.meteor.codec.Codec
 import _root_.meteor.syntax._
 import com.ovoenergy.comms.deduplication.Generators._
 import com.ovoenergy.comms.deduplication.meteor.codecs._
+import com.ovoenergy.comms.deduplication.meteor.model.EncodedResult
 import com.ovoenergy.comms.deduplication.model._
 import java.time.Instant
 import java.{util => ju}
@@ -26,13 +27,13 @@ class MeteorCodecSuite extends munit.ScalaCheckSuite {
       classTag: ClassTag[T]
   ): Unit = {
     property(s"should encode/decode ${classTag.runtimeClass}") {
-      val codec = Codec[Process[T, T, AttributeValue]]
+      val codec = Codec[Process[T, T, EncodedResult]]
       forAll { proc: Process[T, T, T] =>
-        val avProc: Process[T, T, AttributeValue] = proc.copy(
-          result = proc.result.map(_.asAttributeValue)
+        val encProc: Process[T, T, EncodedResult] = proc.copy(
+          result = proc.result.map(v => EncodedResult(v.asAttributeValue))
         )
-        val result = codec.read(codec.write(avProc))
-        assertEquals(result, Right(avProc))
+        val result = codec.read(codec.write(encProc))
+        assertEquals(result, Right(encProc))
       }
     }
   }


### PR DESCRIPTION
The current implementation of `MeteorDeduplication` doesn't allow for the return type of a Process to be an `Option[A]` or `Unit`.
The root cause of the issue is that the result of a process is stored in dynamo as a plain optional field, making it impossible to distinguish between a process that successfully returned `None` or `Unit` and a process that never returned, as in all three scenarios the field value would be `null` in dynamo.

To fix the issue I updated `MeteorDeduplication` to use an `EncodedResult` case class for the `result` field and represent it as a map in dynamo.