### PR TITLE
:wrench: Onboard Scala Steward

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,19 @@
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+name: Scala Steward
+jobs:
+  scala-steward:
+    runs-on: ubuntu-latest
+    name: Launch Scala Steward
+    steps:
+      - name: Launch Scala Steward
+        uses: scala-steward-org/scala-steward-action@v2
+        with:
+          branches: master
+          author-name: kaluza-libraries
+          author-email: 123489691+kaluza-libraries@users.noreply.github.com
+          github-token: ${{ secrets.KALUZA_LIBRARIES_SCALA_STEWARD_TOKEN }}
+          other-args: "--add-labels"


### PR DESCRIPTION
Onboards [Scala Steward GHA](https://github.com/scala-steward-org/scala-steward-action) to run periodically or on-demand.

For questions or feedback contact the Kaluza Scala Caretaker team in [#ug-scala](https://kaluza.slack.com/archives/C054STLBRCP).

### Requirements
Scala Steward requires the following to run:
- [X] `kaluza-libraries` must have `writer` permissions to the repo.
- [X] `KALUZA_LIBRARIES_SCALA_STEWARD_TOKEN` secret must be available (created by following the onboarding workflow).

### Private dependencies

**By default, Scala Steward does not scan private dependencies (https://kaluza.jfrog.io/ui/repos/tree/General/maven-private)**.

If your project uses private dependencies and is following the [artifactory setup standards](https://ovotech.atlassian.net/wiki/spaces/KAL/pages/3727425780/Scala#Using-Kaluza-private-libraries), we suggest enabling private repository scanning:
1. Go to fusion and add the organization secrets `ARTIFACTORY_USER_READONLY` and `ARTIFACTORY_TOKEN_READONLY`.                  
2. Add the following arguments under `other-args:` in `scala-steward.yml`:
```
--env-var ARTIFACTORY_USER=${{ secrets.ARTIFACTORY_USER_READONLY }} --env-var ARTIFACTORY_PASS=${{ secrets.ARTIFACTORY_TOKEN_READONLY }}
```

These tokens are not available automatically because OVO and Kaluza share the same Github organization.

### How to test

Once merged go to `Actions` → `Scala Steward` → `Run workflow` → `Run workflow`. 

Scala Steward will open new pull-requests if there are outdated dependencies.

### Automation

We suggest setting up an automated job to merge Scala Steward pull requests automatically (see [onboarding guide](https://ovotech.atlassian.net/wiki/spaces/KAL/pages/4272881983/Setup+GHA+with+Scala+Steward+Mergify)).